### PR TITLE
Update incompaatible_mods.txt - updates #91

### DIFF
--- a/TLM/TLM/Resources/incompatible_mods.txt
+++ b/TLM/TLM/Resources/incompatible_mods.txt
@@ -14,7 +14,6 @@
 512341354;Central Services Dispatcher (WtM)
 844180955;City Drive
 529979180;CSL Service Reserve
-1647686914;AdvancedJunctionRule
 583556014;Enhanced Hearse AI [Fixed for v1.4+]
 433249875;[ARIS] Enhanced Hearse AI
 583552152;Enhanced Garbage Truck AI [Fixed for v1.4+]


### PR DESCRIPTION
AdvancedJunctionRule is not incompatible with TM:PE, it *relies* on TM:PE! So removed it from the incompatible mods list lol.

See #90 (different issue) for related details.