### PR TITLE
Turn on red toggle fix

### DIFF
--- a/TLM/TLM/Manager/IJunctionRestrictionsManager.cs
+++ b/TLM/TLM/Manager/IJunctionRestrictionsManager.cs
@@ -15,7 +15,7 @@ namespace TrafficManager.Manager {
 		bool IsUturnAllowedConfigurable(ushort segmentId, bool startNode, ref NetNode node);
 
         /// <summary>
-		/// Determines if turn-on-red behavior may be controlled at the given segment end.
+		/// Determines if turn-on-red behavior is enabled and may be controlled at the given segment end.
 		/// </summary>
 		/// <param name="segmentId">segment id</param>
 		/// <param name="startNode">at start node?</param>

--- a/TLM/TLM/Traffic/Data/SegmentEndFlags.cs
+++ b/TLM/TLM/Traffic/Data/SegmentEndFlags.cs
@@ -48,7 +48,7 @@ namespace TrafficManager.Traffic.Data {
 			}
 
 			defaultUturnAllowed = junctionRestrictionsManager.GetDefaultUturnAllowed(segmentId, startNode, ref node);
-            defaultTurnOnRedAllowed = junctionRestrictionsManager.GetDefaultTurnOnRedAllowed(segmentId, startNode, ref node);
+			defaultTurnOnRedAllowed = junctionRestrictionsManager.GetDefaultTurnOnRedAllowed(segmentId, startNode, ref node);
 			defaultStraightLaneChangingAllowed = junctionRestrictionsManager.GetDefaultLaneChangingAllowedWhenGoingStraight(segmentId, startNode, ref node);
 			defaultEnterWhenBlockedAllowed = junctionRestrictionsManager.GetDefaultEnteringBlockedJunctionAllowed(segmentId, startNode, ref node);
 			defaultPedestrianCrossingAllowed = junctionRestrictionsManager.GetDefaultPedestrianCrossingAllowed(segmentId, startNode, ref node);
@@ -72,6 +72,10 @@ namespace TrafficManager.Traffic.Data {
             }
 
             return TernaryBoolUtil.ToBool(turnOnRedAllowed);
+        }
+
+        public bool IsTurnOnRedSet() {
+	        return turnOnRedAllowed != TernaryBool.Undefined;
         }
 
 		public bool IsLaneChangingAllowedWhenGoingStraight() {

--- a/TLM/TLM/Traffic/Data/SegmentFlags.cs
+++ b/TLM/TLM/Traffic/Data/SegmentFlags.cs
@@ -22,6 +22,10 @@ namespace TrafficManager.Traffic.Data {
             return startNode ? startNodeFlags.IsTurnOnRedAllowed() : endNodeFlags.IsTurnOnRedAllowed();
         }
 
+        public bool IsTurnOnRedValueSet(bool startNode) {
+	        return startNode ? startNodeFlags.IsTurnOnRedSet() : endNodeFlags.IsTurnOnRedSet();
+        }
+
 		public bool IsLaneChangingAllowedWhenGoingStraight(bool startNode) {
 			return startNode ? startNodeFlags.IsLaneChangingAllowedWhenGoingStraight() : endNodeFlags.IsLaneChangingAllowedWhenGoingStraight();
 		}

--- a/TLM/TLM/UI/SubTools/JunctionRestrictionsTool.cs
+++ b/TLM/TLM/UI/SubTools/JunctionRestrictionsTool.cs
@@ -280,11 +280,15 @@ namespace TrafficManager.UI.SubTools {
                 // draw "turn on red allowed" sign at (2; 0)
                 allowed = JunctionRestrictionsManager.Instance.IsTurnOnRedAllowed(segmentId, startNode);
                 configurable = Constants.ManagerFactory.JunctionRestrictionsManager.IsTurnOnRedAllowedConfigurable(segmentId, startNode, ref node);
+                bool defaultAllowed = Constants.ManagerFactory.JunctionRestrictionsManager.GetDefaultTurnOnRedAllowed(segmentId, startNode, ref node);
+                bool turnOnRedValueSet = JunctionRestrictionsManager.Instance.IsTurnOnRedValueSet(segmentId, startNode);
                 if (
                     debug ||
-                    (configurable && Options.turnOnRed &&
-                    (!viewOnly || allowed != Constants.ManagerFactory.JunctionRestrictionsManager.GetDefaultTurnOnRedAllowed(segmentId, startNode, ref node)))
+                    (configurable &&
+                    ((!viewOnly || allowed || turnOnRedValueSet)))
                 ) {
+	                // allowed only if value set to true or default is true
+	                allowed = turnOnRedValueSet ? allowed : defaultAllowed;
                     if (Constants.ServiceFactory.SimulationService.LeftHandDrive) {
                         DrawSign(viewOnly, !configurable, ref camPos, ref xu, ref yu, f, ref zero, x, y, guiColor, allowed ? TextureResources.LeftOnRedAllowedTexture2D : TextureResources.LeftOnRedForbiddenTexture2D, out signHovered);
                     } else {

--- a/TLM/TLM/UI/SubTools/JunctionRestrictionsTool.cs
+++ b/TLM/TLM/UI/SubTools/JunctionRestrictionsTool.cs
@@ -285,7 +285,7 @@ namespace TrafficManager.UI.SubTools {
                 if (
                     debug ||
                     (configurable &&
-                    ((!viewOnly || allowed || turnOnRedValueSet)))
+                    ((!viewOnly || (turnOnRedValueSet && allowed != defaultAllowed))))
                 ) {
 	                // allowed only if value set to true or default is true
 	                allowed = turnOnRedValueSet ? allowed : defaultAllowed;


### PR DESCRIPTION
Fixes #102 
Finally after 4 hours of fighting with enable conditions, issue seems to be fixed.
Please check saving settings if you can 😉

Current behavior after fix: (_value_ means current state of turn on red for selected segment)
- if __no__ value set - gui shows state of default "Turn on red" behavior setting
- if value changed (touched):
    - gui shows values which were set + preview
    - gui always show chosen value for junction segment no matter which default behavior was set (behavior is always equal to value set)