### PR TITLE
#218: Parking AI despawns vehicles

### DIFF
--- a/TLM/TLM/Custom/AI/CustomCarAI.cs
+++ b/TLM/TLM/Custom/AI/CustomCarAI.cs
@@ -65,8 +65,10 @@ namespace TrafficManager.Custom.AI {
 					ushort driverInstanceId = CustomPassengerCarAI.GetDriverInstanceId(vehicleId, ref vehicleData);
 					finalPathState = AdvancedParkingManager.Instance.UpdateCarPathState(vehicleId, ref vehicleData, ref Singleton<CitizenManager>.instance.m_instances.m_buffer[driverInstanceId], ref ExtCitizenInstanceManager.Instance.ExtInstances[driverInstanceId], mainPathState);
 
+#if DEBUG
 					if (debug)
 						Log._Debug($"CustomCarAI.CustomSimulationStep({vehicleId}): Applied Parking AI logic. Path: {vehicleData.m_path}, mainPathState={mainPathState}, finalPathState={finalPathState}");
+#endif
 				}
 #if BENCHMARK
 				}

--- a/TLM/TLM/Custom/AI/CustomCarAI.cs
+++ b/TLM/TLM/Custom/AI/CustomCarAI.cs
@@ -116,7 +116,7 @@ namespace TrafficManager.Custom.AI {
 						// path mode has been updated, repeat path-finding
 						vehicleData.m_flags &= ~Vehicle.Flags.WaitingPath;
 						this.InvalidPath(vehicleId, ref vehicleData, vehicleId, ref vehicleData);
-						return;
+						break;
 				}
 				// NON-STOCK CODE END
 			} else {
@@ -133,7 +133,7 @@ namespace TrafficManager.Custom.AI {
 #if BENCHMARK
 			}
 #endif
-			if (!Options.isStockLaneChangerUsed()) {
+			if (!Options.isStockLaneChangerUsed() && (vehicleData.m_flags & Vehicle.Flags.Spawned) != 0) {
 #if BENCHMARK
 				using (var bm = new Benchmark(null, "LogTraffic")) {
 #endif

--- a/TLM/TLM/Custom/AI/CustomCarAI.cs
+++ b/TLM/TLM/Custom/AI/CustomCarAI.cs
@@ -34,6 +34,12 @@ namespace TrafficManager.Custom.AI {
 		/// <param name="vehicleData"></param>
 		/// <param name="physicsLodRefPos"></param>
 		public void CustomSimulationStep(ushort vehicleId, ref Vehicle vehicleData, Vector3 physicsLodRefPos) {
+#if DEBUG
+			bool vehDebug = GlobalConfig.Instance.Debug.CitizenId == 0 || GlobalConfig.Instance.Debug.VehicleId == vehicleId;
+			bool debug = GlobalConfig.Instance.Debug.Switches[2] && vehDebug;
+			bool fineDebug = GlobalConfig.Instance.Debug.Switches[4] && vehDebug;
+#endif
+
 			if ((vehicleData.m_flags & Vehicle.Flags.WaitingPath) != 0) {
 				PathManager pathManager = Singleton<PathManager>.instance;
 				byte pathFindFlags = pathManager.m_pathUnits.m_buffer[vehicleData.m_path].m_pathFindFlags;
@@ -46,30 +52,73 @@ namespace TrafficManager.Custom.AI {
 					mainPathState = ExtPathState.Ready;
 				}
 
+#if DEBUG
+				if (debug)
+					Log._Debug($"CustomCarAI.CustomSimulationStep({vehicleId}): Path: {vehicleData.m_path}, mainPathState={mainPathState}");
+#endif
+				ExtSoftPathState finalPathState = ExtSoftPathState.None;
 #if BENCHMARK
 				using (var bm = new Benchmark(null, "UpdateCarPathState")) {
 #endif
-					if (Options.prohibitPocketCars && VehicleStateManager.Instance.VehicleStates[vehicleId].vehicleType == ExtVehicleType.PassengerCar) {
-						mainPathState = AdvancedParkingManager.Instance.UpdateCarPathState(vehicleId, ref vehicleData, ref ExtCitizenInstanceManager.Instance.ExtInstances[CustomPassengerCarAI.GetDriverInstanceId(vehicleId, ref vehicleData)], mainPathState);
-					}
+				finalPathState = ExtCitizenInstance.ConvertPathStateToSoftPathState(mainPathState);
+				if (Options.prohibitPocketCars && VehicleStateManager.Instance.VehicleStates[vehicleId].vehicleType == ExtVehicleType.PassengerCar) {
+					ushort driverInstanceId = CustomPassengerCarAI.GetDriverInstanceId(vehicleId, ref vehicleData);
+					finalPathState = AdvancedParkingManager.Instance.UpdateCarPathState(vehicleId, ref vehicleData, ref Singleton<CitizenManager>.instance.m_instances.m_buffer[driverInstanceId], ref ExtCitizenInstanceManager.Instance.ExtInstances[driverInstanceId], mainPathState);
+
+					if (debug)
+						Log._Debug($"CustomCarAI.CustomSimulationStep({vehicleId}): Applied Parking AI logic. Path: {vehicleData.m_path}, mainPathState={mainPathState}, finalPathState={finalPathState}");
+				}
 #if BENCHMARK
 				}
 #endif
-				// NON-STOCK CODE END
 
-				if (mainPathState == ExtPathState.Ready) {
-					vehicleData.m_pathPositionIndex = 255;
-					vehicleData.m_flags &= ~Vehicle.Flags.WaitingPath;
-					vehicleData.m_flags &= ~Vehicle.Flags.Arriving;
-					this.PathfindSuccess(vehicleId, ref vehicleData);
-					this.TrySpawn(vehicleId, ref vehicleData);
-				} else if (mainPathState == ExtPathState.Failed) {
-					vehicleData.m_flags &= ~Vehicle.Flags.WaitingPath;
-					Singleton<PathManager>.instance.ReleasePath(vehicleData.m_path);
-					vehicleData.m_path = 0u;
-					this.PathfindFailure(vehicleId, ref vehicleData);
-					return;
+				switch (finalPathState) {
+					case ExtSoftPathState.Ready:
+#if DEBUG
+						if (debug)
+							Log._Debug($"CustomCarAI.CustomSimulationStep({vehicleId}): Path-finding succeeded for vehicle {vehicleId} (finalPathState={finalPathState}). Path: {vehicleData.m_path} -- calling CarAI.PathfindSuccess");
+#endif
+
+						vehicleData.m_pathPositionIndex = 255;
+						vehicleData.m_flags &= ~Vehicle.Flags.WaitingPath;
+						vehicleData.m_flags &= ~Vehicle.Flags.Arriving;
+						this.PathfindSuccess(vehicleId, ref vehicleData);
+						this.TrySpawn(vehicleId, ref vehicleData);
+						break;
+					case ExtSoftPathState.Ignore:
+#if DEBUG
+						if (debug)
+							Log._Debug($"CustomCarAI.CustomSimulationStep({vehicleId}): Path-finding result shall be ignored for vehicle {vehicleId} (finalPathState={finalPathState}). Path: {vehicleData.m_path} -- ignoring");
+#endif
+						return;
+					case ExtSoftPathState.Calculating:
+					default:
+#if DEBUG
+						if (debug)
+							Log._Debug($"CustomCarAI.CustomSimulationStep({vehicleId}): Path-finding result undetermined for vehicle {vehicleId} (finalPathState={finalPathState}). Path: {vehicleData.m_path} -- continue");
+#endif
+						break;
+					case ExtSoftPathState.FailedHard:
+#if DEBUG
+						if (debug)
+							Log._Debug($"CustomCarAI.CustomSimulationStep({vehicleId}): HARD path-finding failure for vehicle {vehicleId} (finalPathState={finalPathState}). Path: {vehicleData.m_path} -- calling CarAI.PathfindFailure");
+#endif
+						vehicleData.m_flags &= ~Vehicle.Flags.WaitingPath;
+						Singleton<PathManager>.instance.ReleasePath(vehicleData.m_path);
+						vehicleData.m_path = 0u;
+						this.PathfindFailure(vehicleId, ref vehicleData);
+						return;
+					case ExtSoftPathState.FailedSoft:
+#if DEBUG
+						if (debug)
+							Log._Debug($"CustomCarAI.CustomSimulationStep({vehicleId}): SOFT path-finding failure for vehicle {vehicleId} (finalPathState={finalPathState}). Path: {vehicleData.m_path} -- calling CarAI.InvalidPath");
+#endif
+						// path mode has been updated, repeat path-finding
+						vehicleData.m_flags &= ~Vehicle.Flags.WaitingPath;
+						this.InvalidPath(vehicleId, ref vehicleData, vehicleId, ref vehicleData);
+						return;
 				}
+				// NON-STOCK CODE END
 			} else {
 				if ((vehicleData.m_flags & Vehicle.Flags.WaitingSpace) != 0) {
 					this.TrySpawn(vehicleId, ref vehicleData);

--- a/TLM/TLM/Custom/AI/CustomCitizenAI.cs
+++ b/TLM/TLM/Custom/AI/CustomCitizenAI.cs
@@ -88,6 +88,7 @@ namespace TrafficManager.Custom.AI {
 						carUsageMode = CarUsagePolicy.Forbidden;
 						break;
 					case ExtPathMode.RequiresCarPath:
+					case ExtPathMode.RequiresDirectCarPathToTarget:
 					case ExtPathMode.DrivingToTarget:
 					case ExtPathMode.DrivingToKnownParkPos:
 					case ExtPathMode.DrivingToAltParkPos:
@@ -152,7 +153,10 @@ namespace TrafficManager.Custom.AI {
 						if (instanceData.m_sourceBuilding != 0) {
 							ItemClass.Service sourceBuildingService = Singleton<BuildingManager>.instance.m_buildings.m_buffer[instanceData.m_sourceBuilding].Info.m_class.m_service;
 
-							if (Constants.ManagerFactory.ExtCitizenInstanceManager.IsAtOutsideConnection(instanceID, ref instanceData, ref citizenManager.m_citizens.m_buffer[instanceData.m_citizen])) {
+							if (
+								(Singleton<BuildingManager>.instance.m_buildings.m_buffer[instanceData.m_sourceBuilding].m_flags & Building.Flags.IncomingOutgoing) != Building.Flags.None &&
+								(startPos - Singleton<BuildingManager>.instance.m_buildings.m_buffer[instanceData.m_sourceBuilding].m_position).magnitude <= GlobalConfig.Instance.ParkingAI.MaxBuildingToPedestrianLaneDistance
+							) {
 								if (sourceBuildingService == ItemClass.Service.Road) {
 									if (vehicleInfo != null) {
 										/*

--- a/TLM/TLM/Custom/AI/CustomCitizenAI.cs
+++ b/TLM/TLM/Custom/AI/CustomCitizenAI.cs
@@ -88,7 +88,7 @@ namespace TrafficManager.Custom.AI {
 						carUsageMode = CarUsagePolicy.Forbidden;
 						break;
 					case ExtPathMode.RequiresCarPath:
-					case ExtPathMode.RequiresDirectCarPathToTarget:
+					case ExtPathMode.RequiresMixedCarPathToTarget:
 					case ExtPathMode.DrivingToTarget:
 					case ExtPathMode.DrivingToKnownParkPos:
 					case ExtPathMode.DrivingToAltParkPos:

--- a/TLM/TLM/Custom/AI/CustomCitizenAI.cs
+++ b/TLM/TLM/Custom/AI/CustomCitizenAI.cs
@@ -554,25 +554,7 @@ namespace TrafficManager.Custom.AI {
 		}
 
 		public bool CustomFindPathPosition(ushort instanceID, ref CitizenInstance citizenData, Vector3 pos, NetInfo.LaneType laneTypes, VehicleInfo.VehicleType vehicleTypes, bool allowUnderground, out PathUnit.Position position) {
-			position = default(PathUnit.Position);
-			float minDist = 1E+10f;
-			PathUnit.Position posA;
-			PathUnit.Position posB;
-			float distA;
-			float distB;
-			if (PathManager.FindPathPosition(pos, ItemClass.Service.Road, laneTypes, vehicleTypes, allowUnderground, false, Options.prohibitPocketCars ? GlobalConfig.Instance.ParkingAI.MaxBuildingToPedestrianLaneDistance : 32f, out posA, out posB, out distA, out distB) && distA < minDist) {
-				minDist = distA;
-				position = posA;
-			}
-			if (PathManager.FindPathPosition(pos, ItemClass.Service.Beautification, laneTypes, vehicleTypes, allowUnderground, false, Options.prohibitPocketCars ? GlobalConfig.Instance.ParkingAI.MaxBuildingToPedestrianLaneDistance : 32f, out posA, out posB, out distA, out distB) && distA < minDist) {
-				minDist = distA;
-				position = posA;
-			}
-			if ((citizenData.m_flags & CitizenInstance.Flags.CannotUseTransport) == CitizenInstance.Flags.None && PathManager.FindPathPosition(pos, ItemClass.Service.PublicTransport, laneTypes, vehicleTypes, allowUnderground, false, Options.prohibitPocketCars ? GlobalConfig.Instance.ParkingAI.MaxBuildingToPedestrianLaneDistance : 32f, out posA, out posB, out distA, out distB) && distA < minDist) {
-				minDist = distA;
-				position = posA;
-			}
-			return position.m_segment != 0;
+			return CustomPathManager.FindCitizenPathPosition(pos, laneTypes, vehicleTypes, (citizenData.m_flags & CitizenInstance.Flags.CannotUseTransport) == CitizenInstance.Flags.None, allowUnderground, out position);
 		}
 
 		// stock code

--- a/TLM/TLM/Custom/AI/CustomHumanAI.cs
+++ b/TLM/TLM/Custom/AI/CustomHumanAI.cs
@@ -123,7 +123,7 @@ namespace TrafficManager.Custom.AI {
 						instanceData.m_flags &= ~CitizenInstance.Flags.WaitingPath;
 						instanceData.m_flags &= ~(CitizenInstance.Flags.HangAround | CitizenInstance.Flags.Panicking | CitizenInstance.Flags.SittingDown | CitizenInstance.Flags.Cheering);
 						this.InvalidPath(instanceID, ref instanceData);
-						return;
+						break;
 				}
 				// NON-STOCK CODE END
 			}

--- a/TLM/TLM/Custom/AI/CustomPassengerCarAI.cs
+++ b/TLM/TLM/Custom/AI/CustomPassengerCarAI.cs
@@ -124,13 +124,13 @@ namespace TrafficManager.Custom.AI {
 #if BENCHMARK
 			using (var bm = new Benchmark(null, "ExtStartPathFind")) {
 #endif
-			return ExtStartPathFind(vehicleID, ref vehicleData, driverInstanceId, ref ExtCitizenInstanceManager.Instance.ExtInstances[driverInstanceId], startPos, endPos, startBothWays, endBothWays, undergroundTarget);
+			return ExtStartPathFind(vehicleID, ref vehicleData, driverInstanceId, ref Singleton<CitizenManager>.instance.m_instances.m_buffer[(int)driverInstanceId], ref ExtCitizenInstanceManager.Instance.ExtInstances[driverInstanceId], startPos, endPos, startBothWays, endBothWays, undergroundTarget);
 #if BENCHMARK
 			}
 #endif
 		}
 
-		public bool ExtStartPathFind(ushort vehicleID, ref Vehicle vehicleData, ushort driverInstanceId, ref ExtCitizenInstance driverExtInstance, Vector3 startPos, Vector3 endPos, bool startBothWays, bool endBothWays, bool undergroundTarget) {
+		public bool ExtStartPathFind(ushort vehicleID, ref Vehicle vehicleData, ushort driverInstanceId, ref CitizenInstance driverInstance, ref ExtCitizenInstance driverExtInstance, Vector3 startPos, Vector3 endPos, bool startBothWays, bool endBothWays, bool undergroundTarget) {
 #if DEBUG
 			bool citDebug = GlobalConfig.Instance.Debug.CitizenId == 0 || GlobalConfig.Instance.Debug.CitizenId == driverExtInstance.GetCitizenId();
 			bool debug = GlobalConfig.Instance.Debug.Switches[2] && citDebug;
@@ -146,9 +146,8 @@ namespace TrafficManager.Custom.AI {
 			float sqrDistA = 0f;
 			float sqrDistB;
 
-			CitizenManager citizenManager = Singleton<CitizenManager>.instance;
-			ushort targetBuildingId = citizenManager.m_instances.m_buffer[(int)driverInstanceId].m_targetBuilding;
-			uint driverCitizenId = citizenManager.m_instances.m_buffer[(int)driverInstanceId].m_citizen;
+			ushort targetBuildingId = driverInstance.m_targetBuilding;
+			uint driverCitizenId = driverInstance.m_citizen;
 
 			// NON-STOCK CODE START
 			bool calculateEndPos = true;
@@ -167,7 +166,13 @@ namespace TrafficManager.Custom.AI {
 					Log.Warning($"CustomPassengerCarAI.ExtStartPathFind({vehicleID}): PathMode={driverExtInstance.pathMode} for vehicle {vehicleID}, driver citizen instance {driverExtInstance.instanceId}!");
 #endif
 
-				if (
+				if (driverExtInstance.pathMode == ExtPathMode.RequiresDirectCarPathToTarget) {
+					driverExtInstance.pathMode = ExtPathMode.CalculatingCarPathToTarget;
+#if DEBUG
+					if (debug)
+						Log._Debug($"CustomPassengerCarAI.ExtStartPathFind({vehicleID}): PathMode was RequiresDirectCarPathToTarget: Parking spaces will NOT be searched beforehand. Setting pathMode={driverExtInstance.pathMode}");
+#endif
+				} else if (
 					driverExtInstance.pathMode != ExtPathMode.ParkingFailed &&
 					targetBuildingId != 0 &&
 					(Singleton<BuildingManager>.instance.m_buildings.m_buffer[targetBuildingId].m_flags & Building.Flags.IncomingOutgoing) != Building.Flags.None
@@ -287,6 +292,18 @@ namespace TrafficManager.Custom.AI {
 			NetInfo.LaneType laneTypes = NetInfo.LaneType.Vehicle;
 			if (!movingToParkingPos) {
 				laneTypes |= NetInfo.LaneType.Pedestrian;
+				
+				if (Options.prohibitPocketCars && (driverInstance.m_flags & CitizenInstance.Flags.CannotUseTransport) == CitizenInstance.Flags.None) {
+					/*
+					 * citizen may use public transport
+					 */
+					laneTypes |= NetInfo.LaneType.PublicTransport;
+
+					uint citizenId = driverInstance.m_citizen;
+					if (citizenId != 0u && (Singleton<CitizenManager>.instance.m_citizens.m_buffer[citizenId].m_flags & Citizen.Flags.Evacuating) != Citizen.Flags.None) {
+						laneTypes |= NetInfo.LaneType.EvacuationTransport;
+					}
+				}
 			}
 			// NON-STOCK CODE END
 
@@ -299,7 +316,7 @@ namespace TrafficManager.Custom.AI {
 				targetBuildingId != 0 &&
 				(
 					Singleton<BuildingManager>.instance.m_buildings.m_buffer[(int)targetBuildingId].Info.m_class.m_service > ItemClass.Service.Office ||
-					(citizenManager.m_instances.m_buffer[driverInstanceId].m_flags & CitizenInstance.Flags.TargetIsNode) != CitizenInstance.Flags.None
+					(driverInstance.m_flags & CitizenInstance.Flags.TargetIsNode) != CitizenInstance.Flags.None
 				)) {
 				randomParking = true;
 			}
@@ -314,7 +331,7 @@ namespace TrafficManager.Custom.AI {
 				foundStartingPos = CustomPathManager.FindPathPosition(startPos, ItemClass.Service.Road, NetInfo.LaneType.Vehicle | NetInfo.LaneType.TransportVehicle, vehicleTypes, allowUnderground, false, 32f, out startPosA, out startPosB, out sqrDistA, out sqrDistB);
 			}
 
-			bool foundEndPos = !calculateEndPos || citizenManager.m_instances.m_buffer[(int)driverInstanceId].Info.m_citizenAI.FindPathPosition(driverInstanceId, ref citizenManager.m_instances.m_buffer[(int)driverInstanceId], endPos, Options.prohibitPocketCars && (targetBuildingId == 0 || (Singleton<BuildingManager>.instance.m_buildings.m_buffer[targetBuildingId].m_flags & Building.Flags.IncomingOutgoing) == Building.Flags.None) ? NetInfo.LaneType.Pedestrian : (laneTypes | NetInfo.LaneType.Pedestrian), vehicleTypes, undergroundTarget, out endPosA);
+			bool foundEndPos = !calculateEndPos || driverInstance.Info.m_citizenAI.FindPathPosition(driverInstanceId, ref driverInstance, endPos, Options.prohibitPocketCars && (targetBuildingId == 0 || (Singleton<BuildingManager>.instance.m_buildings.m_buffer[targetBuildingId].m_flags & Building.Flags.IncomingOutgoing) == Building.Flags.None) ? NetInfo.LaneType.Pedestrian : (laneTypes | NetInfo.LaneType.Pedestrian), vehicleTypes, undergroundTarget, out endPosA);
 			// NON-STOCK CODE END
 
 			if (foundStartingPos &&
@@ -479,7 +496,7 @@ namespace TrafficManager.Custom.AI {
 				if (prohibitPocketCars) {
 #if DEBUG
 					if (debug)
-						Log._Debug($"Vehicle {vehicleID} tries to park on a parking position now (flags: {vehicleData.m_flags})! CurrentPathMode={driverExtInstance.pathMode} path={vehicleData.m_path} pathPositionIndex={vehicleData.m_pathPositionIndex} segmentId={pathPos.m_segment} laneIndex={pathPos.m_lane} offset={pathPos.m_offset} nextPath={nextPath} refPos={refPos} searchDir={searchDir} home={homeID} driverCitizenId={driverCitizenId} driverCitizenInstanceId={driverCitizenInstanceId}");
+						Log._Debug($"CustomPassengerCarAI.ExtParkVehicle({vehicleID}): Vehicle {vehicleID} tries to park on a parking position now (flags: {vehicleData.m_flags})! CurrentPathMode={driverExtInstance.pathMode} path={vehicleData.m_path} pathPositionIndex={vehicleData.m_pathPositionIndex} segmentId={pathPos.m_segment} laneIndex={pathPos.m_lane} offset={pathPos.m_offset} nextPath={nextPath} refPos={refPos} searchDir={searchDir} home={homeID} driverCitizenId={driverCitizenId} driverCitizenInstanceId={driverCitizenInstanceId}");
 #endif
 
 					if (driverExtInstance.pathMode == ExtCitizenInstance.ExtPathMode.DrivingToAltParkPos || driverExtInstance.pathMode == ExtCitizenInstance.ExtPathMode.DrivingToKnownParkPos) {
@@ -520,22 +537,26 @@ namespace TrafficManager.Custom.AI {
 					foundParkingSpace = /*prohibitPocketCars ?*/
 						CustomFindParkingSpace(this.m_info, homeID, refPos, searchDir, pathPos.m_segment, out parkPos, out parkRot, out parkOffset) /*:
 						FindParkingSpace(homeID, refPos, searchDir, pathPos.m_segment, this.m_info.m_generatedInfo.m_size.x, this.m_info.m_generatedInfo.m_size.z, out parkPos, out parkRot, out parkOffset)*/;
+#if DEBUG
+					if (debug)
+						Log._Debug($"CustomPassengerCarAI.ExtParkVehicle({vehicleID}): Found parking space? {foundParkingSpace}. parkPos={parkPos}, parkRot={parkRot}, parkOffset={parkOffset}");
+#endif
 				}
 
 				// NON-STOCK CODE END
 				ushort parkedVehicleId = 0;
 				bool parkedCarCreated = foundParkingSpace && vehicleManager.CreateParkedVehicle(out parkedVehicleId, ref Singleton<SimulationManager>.instance.m_randomizer, this.m_info, parkPos, parkRot, driverCitizenId);
+#if DEBUG
+				if (debug)
+					Log._Debug($"CustomPassengerCarAI.ExtParkVehicle({vehicleID}): Parked car created? {parkedCarCreated}");
+#endif
+
 				if (foundParkingSpace && parkedCarCreated) {
 					// we have reached a parking position
 #if DEBUG
 					float sqrDist = (refPos - parkPos).sqrMagnitude;
 					if (fineDebug)
-						Log._Debug($"Vehicle {vehicleID} succeeded in parking! CurrentPathMode={driverExtInstance.pathMode} sqrDist={sqrDist}");
-
-					if (GlobalConfig.Instance.Debug.Switches[6] && sqrDist >= 16000) {
-						Log._Debug($"CustomPassengerCarAI.CustomParkVehicle: FORCED PAUSE. Distance very large! Vehicle {vehicleID}. dist={sqrDist}");
-						Singleton<SimulationManager>.instance.SimulationPaused = true;
-					}
+						Log._Debug($"CustomPassengerCarAI.ExtParkVehicle({vehicleID}): Vehicle {vehicleID} succeeded in parking! CurrentPathMode={driverExtInstance.pathMode} sqrDist={sqrDist}");
 #endif
 
 					driverCitizen.SetParkedVehicle(driverCitizenId, parkedVehicleId);
@@ -558,14 +579,22 @@ namespace TrafficManager.Custom.AI {
 						driverExtInstance.parkingSpaceLocationId = 0;
 #if DEBUG
 						if (debug)
-							Log._Debug($"Vehicle {vehicleID} has reached an (alternative) parking position! CurrentPathMode={driverExtInstance.pathMode} position={parkPos}");
+							Log._Debug($"CustomPassengerCarAI.ExtParkVehicle({vehicleID}): Vehicle {vehicleID} has reached an (alternative) parking position! CurrentPathMode={driverExtInstance.pathMode} position={parkPos}");
 #endif
 						//}
 					}
 				} else if (prohibitPocketCars) {
 					// could not find parking space. vehicle would despawn.
-					if (targetBuildingId != 0 && Constants.ManagerFactory.ExtCitizenInstanceManager.IsAtOutsideConnection(driverCitizenInstanceId, ref driverInstance, ref driverCitizen)) {
-						// target is an outside connection
+					if (
+						targetBuildingId != 0 &&
+						(Singleton<BuildingManager>.instance.m_buildings.m_buffer[targetBuildingId].m_flags & Building.Flags.IncomingOutgoing) != Building.Flags.None &&
+						(refPos - Singleton<BuildingManager>.instance.m_buildings.m_buffer[targetBuildingId].m_position).magnitude <= GlobalConfig.Instance.ParkingAI.MaxBuildingToPedestrianLaneDistance
+					) {
+						// vehicle is at target and target is an outside connection: accept despawn
+#if DEBUG
+						if (debug)
+							Log._Debug($"CustomPassengerCarAI.ExtParkVehicle({vehicleID}): Driver citizen instance {driverCitizenInstanceId} wants to park at an outside connection. Aborting.");
+#endif
 						return true;
 					}
 
@@ -579,11 +608,15 @@ namespace TrafficManager.Custom.AI {
 					}
 
 					if (!foundParkingSpace) {
+#if DEBUG
+						if (debug)
+							Log._Debug($"CustomPassengerCarAI.ExtParkVehicle({vehicleID}): Parking failed for vehicle {vehicleID}: Could not find parking space. ABORT.");
+#endif
 						++driverExtInstance.failedParkingAttempts;
 					} else {
 #if DEBUG
 						if (debug)
-							Log._Debug($"Parking failed for vehicle {vehicleID}: Parked car could not be created. ABORT.");
+							Log._Debug($"CustomPassengerCarAI.ExtParkVehicle({vehicleID}): Parking failed for vehicle {vehicleID}: Parked car could not be created. ABORT.");
 #endif
 						driverExtInstance.failedParkingAttempts = GlobalConfig.Instance.ParkingAI.MaxParkingAttempts + 1;
 					}
@@ -592,7 +625,7 @@ namespace TrafficManager.Custom.AI {
 
 #if DEBUG
 					if (debug)
-						Log._Debug($"Parking failed for vehicle {vehicleID}! (flags: {vehicleData.m_flags}) pathPos segment={pathPos.m_segment}, lane={pathPos.m_lane}, offset={pathPos.m_offset}. Trying to find parking space in the vicinity. FailedParkingAttempts={driverExtInstance.failedParkingAttempts}, CurrentPathMode={driverExtInstance.pathMode} foundParkingSpace={foundParkingSpace}");
+						Log._Debug($"CustomPassengerCarAI.ExtParkVehicle({vehicleID}): Parking failed for vehicle {vehicleID}! (flags: {vehicleData.m_flags}) pathPos segment={pathPos.m_segment}, lane={pathPos.m_lane}, offset={pathPos.m_offset}. Trying to find parking space in the vicinity. FailedParkingAttempts={driverExtInstance.failedParkingAttempts}, CurrentPathMode={driverExtInstance.pathMode} foundParkingSpace={foundParkingSpace}");
 #endif
 
 					// invalidate paths of all passengers in order to force path recalculation
@@ -608,12 +641,12 @@ namespace TrafficManager.Custom.AI {
 
 #if DEBUG
 									if (debug)
-										Log._Debug($"Releasing path for citizen instance {citizenInstanceId} sitting in vehicle {vehicleID} (was {citizenManager.m_instances.m_buffer[citizenInstanceId].m_path}).");
+										Log._Debug($"CustomPassengerCarAI.ExtParkVehicle({vehicleID}): Releasing path for citizen instance {citizenInstanceId} sitting in vehicle {vehicleID} (was {citizenManager.m_instances.m_buffer[citizenInstanceId].m_path}).");
 #endif
 									if (citizenInstanceId != driverCitizenInstanceId) {
 #if DEBUG
 										if (debug)
-											Log._Debug($"Resetting pathmode for passenger citizen instance {citizenInstanceId} sitting in vehicle {vehicleID} (was {ExtCitizenInstanceManager.Instance.ExtInstances[citizenInstanceId].pathMode}).");
+											Log._Debug($"CustomPassengerCarAI.ExtParkVehicle({vehicleID}): Resetting pathmode for passenger citizen instance {citizenInstanceId} sitting in vehicle {vehicleID} (was {ExtCitizenInstanceManager.Instance.ExtInstances[citizenInstanceId].pathMode}).");
 #endif
 
 										ExtCitizenInstanceManager.Instance.ExtInstances[citizenInstanceId].Reset();
@@ -655,7 +688,7 @@ namespace TrafficManager.Custom.AI {
 									if (driverExtInstance.pathMode == ExtCitizenInstance.ExtPathMode.RequiresWalkingPathToTarget) {
 #if DEBUG
 										if (debug)
-											Log._Debug($"Parking succeeded: Doing nothing for citizen instance {citizenInstanceId}! path: {citizenManager.m_instances.m_buffer[(int)citizenInstanceId].m_path}");
+											Log._Debug($"CustomPassengerCarAI.ExtParkVehicle({vehicleID}): Parking succeeded: Doing nothing for citizen instance {citizenInstanceId}! path: {citizenManager.m_instances.m_buffer[(int)citizenInstanceId].m_path}");
 #endif
 										ExtCitizenInstanceManager.Instance.ExtInstances[citizenInstanceId].pathMode = ExtCitizenInstance.ExtPathMode.RequiresWalkingPathToTarget;
 										continue;
@@ -672,7 +705,7 @@ namespace TrafficManager.Custom.AI {
 									citizenManager.m_instances.m_buffer[(int)citizenInstanceId].m_lastPathOffset = segmentOffset;
 #if DEBUG
 									if (debug)
-										Log._Debug($"Parking succeeded (default): Setting path of citizen instance {citizenInstanceId} to {nextPath}!");
+										Log._Debug($"CustomPassengerCarAI.ExtParkVehicle({vehicleID}): Parking succeeded (default): Setting path of citizen instance {citizenInstanceId} to {nextPath}!");
 #endif
 								}
 							}
@@ -690,7 +723,7 @@ namespace TrafficManager.Custom.AI {
 				if (driverExtInstance.pathMode == ExtCitizenInstance.ExtPathMode.RequiresWalkingPathToTarget) {
 #if DEBUG
 					if (debug)
-						Log._Debug($"Parking succeeded (alternative parking spot): Citizen instance {driverExtInstance} has to walk for the remaining path!");
+						Log._Debug($"CustomPassengerCarAI.ExtParkVehicle({vehicleID}): Parking succeeded (alternative parking spot): Citizen instance {driverExtInstance} has to walk for the remaining path!");
 #endif
 					/*driverExtInstance.CurrentPathMode = ExtCitizenInstance.PathMode.CalculatingWalkingPathToTarget;
 					if (debug)

--- a/TLM/TLM/Custom/AI/CustomTrainAI.cs
+++ b/TLM/TLM/Custom/AI/CustomTrainAI.cs
@@ -54,7 +54,7 @@ namespace TrafficManager.Custom.AI {
 #if BENCHMARK
 			}
 #endif
-			if (!Options.isStockLaneChangerUsed()) {
+			if (!Options.isStockLaneChangerUsed() && (vehicleData.m_flags & Vehicle.Flags.Spawned) != 0) {
 #if BENCHMARK
 				using (var bm = new Benchmark(null, "LogTraffic")) {
 #endif

--- a/TLM/TLM/Custom/AI/CustomTramBaseAI.cs
+++ b/TLM/TLM/Custom/AI/CustomTramBaseAI.cs
@@ -56,7 +56,7 @@ namespace TrafficManager.Custom.AI {
 #if BENCHMARK
 			}
 #endif
-			if (!Options.isStockLaneChangerUsed()) {
+			if (!Options.isStockLaneChangerUsed() && (vehicleData.m_flags & Vehicle.Flags.Spawned) != 0) {
 #if BENCHMARK
 				using (var bm = new Benchmark(null, "LogTraffic")) {
 #endif

--- a/TLM/TLM/Custom/PathFinding/CustomPathFind2.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathFind2.cs
@@ -2069,7 +2069,7 @@ namespace TrafficManager.Custom.PathFinding {
 			for (; nextLaneIndex <= maxNextLaneIndex && nextLaneId != 0; nextLaneIndex++) {
 				NetInfo.Lane nextLaneInfo = nextSegmentInfo.m_lanes[nextLaneIndex];
 				if ((nextLaneInfo.m_finalDirection & nextFinalDir) != NetInfo.Direction.None) {
-					if (nextLaneInfo.CheckType(allowedLaneTypes, allowedVehicleTypes) && (nextSegmentId != item.m_position.m_segment || nextLaneIndex != item.m_position.m_lane) && (nextLaneInfo.m_finalDirection & nextFinalDir) != NetInfo.Direction.None) {
+					if (nextLaneInfo.CheckType(allowedLaneTypes, allowedVehicleTypes) && (nextSegmentId != item.m_position.m_segment || nextLaneIndex != item.m_position.m_lane)) {
 						if (acuteTurningAngle && nextLaneInfo.m_laneType == NetInfo.LaneType.Vehicle && (nextLaneInfo.m_vehicleType & VehicleInfo.VehicleType.Car) == VehicleInfo.VehicleType.None) {
 							continue;
 						}
@@ -2312,8 +2312,26 @@ namespace TrafficManager.Custom.PathFinding {
 #endif
 							nextItem, item.m_position
 						);
+					} else {
+#if DEBUG
+						if (debug) {
+							Debug(unitId, item, nextSegmentId, nextLaneIndex, nextLaneId, $"ProcessItemCosts: Lane type and/or vehicle type mismatch or same segment/lane. Skipping."
+								+ "\t" + $"allowedLaneTypes={allowedLaneTypes}\n"
+								+ "\t" + $"allowedVehicleTypes={allowedVehicleTypes}"
+							);
+						}
+#endif
 					}
 				} else {
+#if DEBUG
+					if (debug) {
+						Debug(unitId, item, nextSegmentId, nextLaneIndex, nextLaneId, $"ProcessItemCosts: Lane direction mismatch. Skipping."
+							+ "\t" + $"nextLaneInfo.m_finalDirection={nextLaneInfo.m_finalDirection}\n"
+							+ "\t" + $"nextFinalDir={nextFinalDir}"
+						);
+					}
+#endif
+
 					if ((nextLaneInfo.m_laneType & prevLaneType) != NetInfo.LaneType.None && (nextLaneInfo.m_vehicleType & prevVehicleType) != VehicleInfo.VehicleType.None) {
 						newLaneIndexFromInner++;
 					}

--- a/TLM/TLM/Custom/PathFinding/CustomPathManager.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathManager.cs
@@ -566,6 +566,39 @@ namespace TrafficManager.Custom.PathFinding {
 			return pathPosA.m_segment != 0;
 		}
 
+		/// <summary>
+		/// Finds a suitable path position for a walking citizen with the given world position.
+		/// </summary>
+		/// <param name="pos">world position</param>
+		/// <param name="laneTypes">allowed lane types</param>
+		/// <param name="vehicleTypes">allowed vehicle types</param>
+		/// <param name="allowTransport">public transport allowed?</param>
+		/// <param name="allowUnderground">underground position allowed?</param>
+		/// <param name="position">resulting path position</param>
+		/// <returns><code>true</code> if a position could be found, <code>false</code> otherwise</returns>
+		public static bool FindCitizenPathPosition(Vector3 pos, NetInfo.LaneType laneTypes, VehicleInfo.VehicleType vehicleTypes, bool allowTransport, bool allowUnderground, out PathUnit.Position position) {
+			// TODO move to ExtPathManager after harmony upgrade
+			position = default(PathUnit.Position);
+			float minDist = 1E+10f;
+			PathUnit.Position posA;
+			PathUnit.Position posB;
+			float distA;
+			float distB;
+			if (PathManager.FindPathPosition(pos, ItemClass.Service.Road, laneTypes, vehicleTypes, allowUnderground, false, Options.prohibitPocketCars ? GlobalConfig.Instance.ParkingAI.MaxBuildingToPedestrianLaneDistance : 32f, out posA, out posB, out distA, out distB) && distA < minDist) {
+				minDist = distA;
+				position = posA;
+			}
+			if (PathManager.FindPathPosition(pos, ItemClass.Service.Beautification, laneTypes, vehicleTypes, allowUnderground, false, Options.prohibitPocketCars ? GlobalConfig.Instance.ParkingAI.MaxBuildingToPedestrianLaneDistance : 32f, out posA, out posB, out distA, out distB) && distA < minDist) {
+				minDist = distA;
+				position = posA;
+			}
+			if (allowTransport && PathManager.FindPathPosition(pos, ItemClass.Service.PublicTransport, laneTypes, vehicleTypes, allowUnderground, false, Options.prohibitPocketCars ? GlobalConfig.Instance.ParkingAI.MaxBuildingToPedestrianLaneDistance : 32f, out posA, out posB, out distA, out distB) && distA < minDist) {
+				minDist = distA;
+				position = posA;
+			}
+			return position.m_segment != 0;
+		}
+
 		/*internal void ResetQueueItem(uint unit) {
 			queueItems[unit].Reset();
 		}*/

--- a/TLM/TLM/Manager/IAdvancedParkingManager.cs
+++ b/TLM/TLM/Manager/IAdvancedParkingManager.cs
@@ -124,19 +124,22 @@ namespace TrafficManager.Manager {
 		/// <summary>
 		/// Merges the current calculation states of the citizen's main path and return path (while driving a passenger car).
 		/// If a definite calculation state can be determined path-find failure/success is handled appropriately.
-		/// The returned path state indicates if further handling must be undertaken by the game.
+		/// The returned (soft) path state indicates if further handling must be undertaken by the game.
 		/// </summary>
 		/// <param name="vehicleId">vehicle that shall be processed</param>
 		/// <param name="vehicleData">vehicle data</param>
+		/// <param name="driverInstance">driver citizen instance</param>
 		/// <param name="driverExtInstance">extended citizen instance data of the driving citizen</param>
 		/// <param name="mainPathState">current state of the citizen instance's main path</param>
 		/// <returns>
 		///		Indication of how (external) game logic should treat this situation:
 		///		<code>Calculating</code>: Paths are still being calculated. Game must await completion.
 		///		<code>Ready</code>: All paths are ready and path-find success must be handled.
-		///		<code>Failed</code>: At least one path calculation failed and the failure must be handled.
+		///		<code>FailedHard</code>: At least one path calculation failed and the failure must be handled.
+		///		<code>FailedSoft</code>: Path-finding must be repeated.
+		///		<code>Ignore</code>: Default citizen behavior must be skipped. 
 		/// </returns>
-		ExtPathState UpdateCarPathState(ushort vehicleId, ref Vehicle vehicleData, ref ExtCitizenInstance driverExtInstance, ExtPathState mainPathState);
+		ExtSoftPathState UpdateCarPathState(ushort vehicleId, ref Vehicle vehicleData, ref CitizenInstance driverInstance, ref ExtCitizenInstance driverExtInstance, ExtPathState mainPathState);
 
 		/// <summary>
 		/// Processes a citizen that is approaching their private car.

--- a/TLM/TLM/Manager/Impl/AdvancedParkingManager.cs
+++ b/TLM/TLM/Manager/Impl/AdvancedParkingManager.cs
@@ -36,7 +36,7 @@ namespace TrafficManager.Manager.Impl {
 						Services.CitizenService.ReleaseCitizenInstance((ushort)citizenInstanceId);
 						break;
 					case ExtPathMode.RequiresCarPath:
-					case ExtPathMode.RequiresDirectCarPathToTarget:
+					case ExtPathMode.RequiresMixedCarPathToTarget:
 					case ExtPathMode.CalculatingCarPathToKnownParkPos:
 					case ExtPathMode.CalculatingCarPathToTarget:
 					case ExtPathMode.DrivingToKnownParkPos:
@@ -1036,7 +1036,7 @@ namespace TrafficManager.Manager.Impl {
 						if (debug)
 							Log._Debug($"AdvancedParkingManager.OnCarPathFindFailure({vehicleId}): Path failed but it may be retried to drive directly to the target / using public transport.");
 #endif
-						driverExtInstance.pathMode = ExtPathMode.RequiresDirectCarPathToTarget;
+						driverExtInstance.pathMode = ExtPathMode.RequiresMixedCarPathToTarget;
 						ret = ExtSoftPathState.FailedSoft;
 					}
 					break;
@@ -1754,7 +1754,7 @@ namespace TrafficManager.Manager.Impl {
 				switch (extInstance.pathMode) {
 					case ExtPathMode.ApproachingParkedCar:
 					case ExtPathMode.RequiresCarPath:
-					case ExtPathMode.RequiresDirectCarPathToTarget:
+					case ExtPathMode.RequiresMixedCarPathToTarget:
 						ret = Translation.GetString("Entering_vehicle") + ", " + ret;
 						break;
 					case ExtPathMode.RequiresWalkingPathToParkedCar:

--- a/TLM/TLM/Manager/Impl/AdvancedParkingManager.cs
+++ b/TLM/TLM/Manager/Impl/AdvancedParkingManager.cs
@@ -36,6 +36,7 @@ namespace TrafficManager.Manager.Impl {
 						Services.CitizenService.ReleaseCitizenInstance((ushort)citizenInstanceId);
 						break;
 					case ExtPathMode.RequiresCarPath:
+					case ExtPathMode.RequiresDirectCarPathToTarget:
 					case ExtPathMode.CalculatingCarPathToKnownParkPos:
 					case ExtPathMode.CalculatingCarPathToTarget:
 					case ExtPathMode.DrivingToKnownParkPos:
@@ -84,18 +85,27 @@ namespace TrafficManager.Manager.Impl {
 			}
 
 			if (mainPathState == ExtPathState.None || mainPathState == ExtPathState.Failed) {
-				// main path failed or non-existing: reset return path
+				// main path failed or non-existing
 #if DEBUG
 				if (debug)
-					Log._Debug($"AdvancedParkingManager.UpdateCitizenPathState({citizenInstanceId}, ..., {mainPathState}): mainPathSate is None or Failed. Resetting instance and returning FAILED.");
+					Log._Debug($"AdvancedParkingManager.UpdateCitizenPathState({citizenInstanceId}, ..., {mainPathState}): mainPathSate is {mainPathState}.");
 #endif
 
 				if (mainPathState == ExtPathState.Failed) {
+#if DEBUG
+					if (debug)
+						Log._Debug($"AdvancedParkingManager.UpdateCitizenPathState({citizenInstanceId}, ..., {mainPathState}): Checking if path-finding may be repeated.");
+#endif
 					return OnCitizenPathFindFailure(citizenInstanceId, ref citizenInstance, ref extInstance, ref extCitizen);
-				}
+				} else {
+#if DEBUG
+					if (debug)
+						Log._Debug($"AdvancedParkingManager.UpdateCitizenPathState({citizenInstanceId}, ..., {mainPathState}): Resetting instance and returning FAILED.");
+#endif
 
-				extInstance.Reset();
-				return ExtSoftPathState.FailedHard;
+					extInstance.Reset();
+					return ExtSoftPathState.FailedHard;
+				}
 			}
 
 			// main path state is READY
@@ -148,14 +158,7 @@ namespace TrafficManager.Manager.Impl {
 			}
 		}
 
-		/// <summary>
-		/// Updates the vehicle's main path state by checking against the return path state
-		/// </summary>
-		/// <param name="vehicleId">vehicle id</param>
-		/// <param name="vehicleData">vehicle data</param>
-		/// <param name="mainPathState">current state of the vehicle's main path</param>
-		/// <returns></returns>
-		public ExtPathState UpdateCarPathState(ushort vehicleId, ref Vehicle vehicleData, ref ExtCitizenInstance driverExtInstance, ExtPathState mainPathState) {
+		public ExtSoftPathState UpdateCarPathState(ushort vehicleId, ref Vehicle vehicleData, ref CitizenInstance driverInstance, ref ExtCitizenInstance driverExtInstance, ExtPathState mainPathState) {
 #if DEBUG
 			bool citDebug = GlobalConfig.Instance.Debug.CitizenId == 0 || GlobalConfig.Instance.Debug.CitizenId == driverExtInstance.GetCitizenId();
 			bool debug = GlobalConfig.Instance.Debug.Switches[2] && citDebug;
@@ -169,7 +172,7 @@ namespace TrafficManager.Manager.Impl {
 				if (fineDebug)
 					Log._Debug($"AdvancedParkingManager.UpdateCarPathState({vehicleId}, ..., {mainPathState}): still calculating main path. returning CALCULATING.");
 #endif
-				return mainPathState;
+				return ExtCitizenInstance.ConvertPathStateToSoftPathState(mainPathState);
 			}
 
 			//ExtCitizenInstance driverExtInstance = ExtCitizenInstanceManager.Instance.GetExtInstance(CustomPassengerCarAI.GetDriverInstance(vehicleId, ref vehicleData));
@@ -180,7 +183,7 @@ namespace TrafficManager.Manager.Impl {
 				if (debug)
 					Log._Debug($"AdvancedParkingManager.UpdateCarPathState({vehicleId}, ..., {mainPathState}): no driver found!");
 #endif
-				return mainPathState;
+				return ExtCitizenInstance.ConvertPathStateToSoftPathState(mainPathState);
 			}
 
 			if (VehicleStateManager.Instance.VehicleStates[vehicleId].vehicleType != ExtVehicleType.PassengerCar) {
@@ -190,17 +193,32 @@ namespace TrafficManager.Manager.Impl {
 					Log._Debug($"AdvancedParkingManager.UpdateCarPathState({vehicleId}, ..., {mainPathState}): not a passenger car!");
 #endif
 				driverExtInstance.Reset();
-				return mainPathState;
+				return ExtCitizenInstance.ConvertPathStateToSoftPathState(mainPathState);
 			}
 
 			if (mainPathState == ExtPathState.None || mainPathState == ExtPathState.Failed) {
 				// main path failed or non-existing: reset return path
 #if DEBUG
 				if (debug)
-					Log._Debug($"AdvancedParkingManager.UpdateCarPathState({vehicleId}, ..., {mainPathState}): mainPathSate is None or Failed. Resetting instance and returning FAILED.");
+					Log._Debug($"AdvancedParkingManager.UpdateCarPathState({vehicleId}, ..., {mainPathState}): mainPathSate is {mainPathState}.");
 #endif
-				driverExtInstance.Reset();
-				return ExtPathState.Failed;
+
+				if (mainPathState == ExtPathState.Failed) {
+#if DEBUG
+					if (debug)
+						Log._Debug($"AdvancedParkingManager.UpdateCarPathState({vehicleId}, ..., {mainPathState}): Checking if path-finding may be repeated.");
+#endif
+					driverExtInstance.ReleaseReturnPath();
+					return OnCarPathFindFailure(vehicleId, ref vehicleData, ref driverInstance, ref driverExtInstance);
+				} else {
+#if DEBUG
+					if (debug)
+						Log._Debug($"AdvancedParkingManager.UpdateCarPathState({vehicleId}, ..., {mainPathState}): Resetting instance and returning FAILED.");
+#endif
+
+					driverExtInstance.Reset();
+					return ExtSoftPathState.FailedHard;
+				}
 			}
 
 			// main path state is READY
@@ -217,14 +235,14 @@ namespace TrafficManager.Manager.Impl {
 						Log._Debug($"AdvancedParkingManager.UpdateCarPathState({vehicleId}, ..., {mainPathState}): return path state is None. Setting pathMode=DrivingToTarget and returning main path state.");
 #endif
 					driverExtInstance.pathMode = ExtPathMode.DrivingToTarget;
-					return mainPathState;
+					return ExtCitizenInstance.ConvertPathStateToSoftPathState(mainPathState);
 				case ExtPathState.Calculating:
 					// return path not read yet: wait for it
 #if DEBUG
 					if (fineDebug)
 						Log._Debug($"AdvancedParkingManager.UpdateCarPathState({vehicleId}, ..., {mainPathState}): return path state is still calculating.");
 #endif
-					return ExtPathState.Calculating;
+					return ExtSoftPathState.Calculating;
 				case ExtPathState.Failed:
 					// no walking path from parking position to target found. flag main path as 'failed'.
 #if DEBUG
@@ -232,7 +250,7 @@ namespace TrafficManager.Manager.Impl {
 						Log._Debug($"AdvancedParkingManager.UpdateCarPathState({vehicleId}, ..., {mainPathState}): Return path {driverExtInstance.returnPathId} FAILED. Forcing path-finding to fail.");
 #endif
 					driverExtInstance.Reset();
-					return ExtPathState.Failed;
+					return ExtSoftPathState.FailedHard;
 				case ExtPathState.Ready:
 					// handle valid return path
 					driverExtInstance.ReleaseReturnPath();
@@ -269,7 +287,7 @@ namespace TrafficManager.Manager.Impl {
 							Log._Debug($"AdvancedParkingManager.UpdateCarPathState({vehicleId}, ..., {mainPathState}): Car path to known parking position is READY for vehicle {vehicleId}! CurrentPathMode={driverExtInstance.pathMode}");
 #endif
 					}
-					return ExtPathState.Ready;
+					return ExtSoftPathState.Ready;
 			}
 		}
 
@@ -971,6 +989,74 @@ namespace TrafficManager.Manager.Impl {
 			return ret;
 		}
 
+		/// <summary>
+		/// Handles a path-finding failure for citizen instances and activated Parking AI.
+		/// </summary>
+		/// <param name="vehicleId">Vehicle id</param>
+		/// <param name="vehicleData">Vehicle data</param>
+		/// <param name="driverInstanceData">Driver citizen instance data</param>
+		/// <param name="driverExtInstance">extended citizen instance information of driver</param>
+		/// <returns>if true path-finding may be repeated (path mode has been updated), false otherwise</returns>
+		protected ExtSoftPathState OnCarPathFindFailure(ushort vehicleId, ref Vehicle vehicleData, ref CitizenInstance driverInstanceData, ref ExtCitizenInstance driverExtInstance) {
+#if DEBUG
+			bool citDebug = (GlobalConfig.Instance.Debug.VehicleId == 0 || GlobalConfig.Instance.Debug.VehicleId == vehicleId) &&
+				(GlobalConfig.Instance.Debug.CitizenInstanceId == 0 || GlobalConfig.Instance.Debug.CitizenInstanceId == driverExtInstance.instanceId) &&
+				(GlobalConfig.Instance.Debug.CitizenId == 0 || GlobalConfig.Instance.Debug.CitizenId == driverExtInstance.GetCitizenId());
+			bool debug = GlobalConfig.Instance.Debug.Switches[2] && citDebug;
+			bool fineDebug = GlobalConfig.Instance.Debug.Switches[4] && citDebug;
+
+			if (debug)
+				Log._Debug($"AdvancedParkingManager.OnCarPathFindFailure({vehicleId}): Path-finding failed for driver citizen instance {driverExtInstance.instanceId}. CurrentPathMode={driverExtInstance.pathMode}");
+#endif
+
+			// update parking demands
+			switch (driverExtInstance.pathMode) {
+				case ExtPathMode.None:
+				case ExtPathMode.CalculatingCarPathToAltParkPos:
+				case ExtPathMode.CalculatingCarPathToKnownParkPos:
+					// could not reach target building by driving: increase parking space demand
+#if DEBUG
+					if (fineDebug)
+						Log._Debug($"AdvancedParkingManager.OnCarPathFindFailure({vehicleId}): Increasing parking space demand of target building {driverInstanceData.m_targetBuilding}");
+#endif
+					if (driverInstanceData.m_targetBuilding != 0) {
+						ExtBuildingManager.Instance.ExtBuildings[driverInstanceData.m_targetBuilding].AddParkingSpaceDemand((uint)GlobalConfig.Instance.ParkingAI.FailedParkingSpaceDemandIncrement);
+					}
+					break;
+			}
+
+			// check if path-finding may be repeated
+			ExtSoftPathState ret = ExtSoftPathState.FailedHard;
+			switch (driverExtInstance.pathMode) {
+				case ExtPathMode.CalculatingCarPathToAltParkPos:
+				case ExtPathMode.CalculatingCarPathToKnownParkPos:
+					// try to drive directly to the target if public transport is allowed
+					if ((driverInstanceData.m_flags & CitizenInstance.Flags.CannotUseTransport) == CitizenInstance.Flags.None) {
+#if DEBUG
+						if (debug)
+							Log._Debug($"AdvancedParkingManager.OnCarPathFindFailure({vehicleId}): Path failed but it may be retried to drive directly to the target / using public transport.");
+#endif
+						driverExtInstance.pathMode = ExtPathMode.RequiresDirectCarPathToTarget;
+						ret = ExtSoftPathState.FailedSoft;
+					}
+					break;
+				default:
+#if DEBUG
+					if (debug)
+						Log._Debug($"AdvancedParkingManager.OnCarPathFindFailure({vehicleId}): Path failed and a direct target is not an option. Resetting driver ext. instance.");
+#endif
+					driverExtInstance.Reset();
+					break;
+			}
+
+#if DEBUG
+			if (debug)
+				Log._Debug($"AdvancedParkingManager.OnCarPathFindFailure({vehicleId}): Setting CurrentPathMode for driver citizen instance {driverExtInstance.instanceId} to {driverExtInstance.pathMode}, ret={ret}");
+#endif
+
+			return ret;
+		}
+
 		public bool TryMoveParkedVehicle(ushort parkedVehicleId, ref VehicleParked parkedVehicle, Vector3 refPos, float maxDistance, ushort homeId) {
 			ExtParkingSpaceLocation parkingSpaceLocation;
 			ushort parkingSpaceLocationId;
@@ -1668,6 +1754,7 @@ namespace TrafficManager.Manager.Impl {
 				switch (extInstance.pathMode) {
 					case ExtPathMode.ApproachingParkedCar:
 					case ExtPathMode.RequiresCarPath:
+					case ExtPathMode.RequiresDirectCarPathToTarget:
 						ret = Translation.GetString("Entering_vehicle") + ", " + ret;
 						break;
 					case ExtPathMode.RequiresWalkingPathToParkedCar:

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -137,32 +137,66 @@ namespace TrafficManager.Manager.Impl {
 			bool fineDebug = GlobalConfig.Instance.Debug.Switches[4] && citDebug;
 
 			if (debug)
-				Log._Debug($"AdvancedParkingManager.OnCitizenPathFindSuccess({instanceId}): Path-finding succeeded for citizen instance {instanceId}. Path: {instanceData.m_path} vehicle={citizenData.m_vehicle}");
+				Log._Debug($"ExtCitizenInstanceManager.IsAtOutsideConnection({instanceId}): called for citizen instance {instanceId}. Path: {instanceData.m_path} vehicle={citizenData.m_vehicle}");
 #endif
 
-			bool isAtOutsideConnection = false;
-			ushort sourceBuildingId = instanceData.m_sourceBuilding;
-
-			if (sourceBuildingId != 0) {
-				isAtOutsideConnection = (Singleton<BuildingManager>.instance.m_buildings.m_buffer[sourceBuildingId].m_flags & Building.Flags.IncomingOutgoing) != Building.Flags.None;// Info.m_buildingAI is OutsideConnectionAI;
-				float distToOutsideConnection = (instanceData.GetLastFramePosition() - Singleton<BuildingManager>.instance.m_buildings.m_buffer[sourceBuildingId].m_position).magnitude;
-				if (isAtOutsideConnection && distToOutsideConnection > GlobalConfig.Instance.ParkingAI.MaxBuildingToPedestrianLaneDistance) {
-					isAtOutsideConnection = false;
+			Citizen.Location location = citizenData.CurrentLocation;
+			switch (location) {
+				case Citizen.Location.Home:
+				case Citizen.Location.Visit:
+				case Citizen.Location.Work:
 #if DEBUG
 					if (fineDebug) {
-						Log._Debug($"AdvancedParkingManager.OnCitizenPathFindSuccess({instanceId}): Source building {sourceBuildingId} of citizen instance {instanceId} is an outside connection but cim is too far away: {distToOutsideConnection}");
+						Log._Debug($"ExtCitizenInstanceManager.IsAtOutsideConnection({instanceId}): Citizen is currently at location {location}. This is not an outside connection.");
 					}
 #endif
-				}
-			} else {
-#if DEBUG
-				if (fineDebug) {
-					Log._Debug($"AdvancedParkingManager.OnCitizenPathFindSuccess({instanceId}): No source building!");
-				}
-#endif
+					return false;
 			}
 
-			return isAtOutsideConnection;
+			bool spawned = (instanceData.m_flags & CitizenInstance.Flags.Character) != CitizenInstance.Flags.None;
+			if (!spawned && (citizenData.m_vehicle == 0 || (Singleton<VehicleManager>.instance.m_vehicles.m_buffer[citizenData.m_vehicle].m_flags & Vehicle.Flags.Spawned) == 0)) {
+#if DEBUG
+				if (fineDebug) {
+					Log._Debug($"ExtCitizenInstanceManager.IsAtOutsideConnection({instanceId}): Citizen instance is not spawned ({instanceData.m_flags}) and does not have a spawned car. Not at an outside connection.");
+				}
+#endif
+				return false;
+			}
+
+			if (instanceData.m_sourceBuilding == 0) {
+#if DEBUG
+				if (fineDebug) {
+					Log._Debug($"ExtCitizenInstanceManager.IsAtOutsideConnection({instanceId}): Citizen instance does not have a source building. Not at an outside connection.");
+				}
+#endif
+				return false;
+			}
+			
+			if ((Singleton<BuildingManager>.instance.m_buildings.m_buffer[instanceData.m_sourceBuilding].m_flags & Building.Flags.IncomingOutgoing) == Building.Flags.None) {
+#if DEBUG
+				if (fineDebug) {
+					Log._Debug($"ExtCitizenInstanceManager.IsAtOutsideConnection({instanceId}): Source building {instanceData.m_sourceBuilding} is not an outside connection.");
+				}
+#endif
+				return false;
+			}
+
+			Vector3 pos;
+			if (spawned) {
+				pos = instanceData.GetLastFramePosition();
+			} else {
+				pos = Singleton<VehicleManager>.instance.m_vehicles.m_buffer[citizenData.m_vehicle].GetLastFramePosition();
+			}
+			
+			bool ret = (pos - Singleton<BuildingManager>.instance.m_buildings.m_buffer[instanceData.m_sourceBuilding].m_position).magnitude <= GlobalConfig.Instance.ParkingAI.MaxBuildingToPedestrianLaneDistance;
+
+#if DEBUG
+			if (fineDebug) {
+				Log._Debug($"ExtCitizenInstanceManager.IsAtOutsideConnection({instanceId}): pos={pos}, spawned={spawned}, ret={ret}");
+			}
+#endif
+
+			return ret;
 		}
 	}
 }

--- a/TLM/TLM/State/ConfigData/Debug.cs
+++ b/TLM/TLM/State/ConfigData/Debug.cs
@@ -21,7 +21,7 @@ namespace TrafficManager.State.ConfigData {
 				false, // 9: debug vehicle to segment end linking
 				false, // 10: prevent routing recalculation on global configuration reload
 				false, // 11: debug junction restrictions
-				false, // 12: pedestrian path-find debug log
+				false, // 12: - unused -
 				false, // 13: priority rules debug
 				false, // 14: disable GUI overlay of citizens having a valid path
 				false, // 15: disable checking of other vehicles for trams

--- a/TLM/TLM/Traffic/Data/ExtCitizenInstance.cs
+++ b/TLM/TLM/Traffic/Data/ExtCitizenInstance.cs
@@ -141,7 +141,13 @@ namespace TrafficManager.Traffic.Data {
 			/// <summary>
 			/// Indicates that the citizen is using a taxi to reach the target
 			/// </summary>
-			TaxiToTarget = 17
+			TaxiToTarget = 17,
+			/// <summary>
+			/// Indicates that the driving citizen requires a direct path to target (driving/public transport)
+			/// where possible transitions between different modes of transport happen as required (thus no search
+			/// for parking spaces is performed beforehand)
+			/// </summary>
+			RequiresDirectCarPathToTarget = 18,
 		}
 
 		public enum ExtParkingSpaceLocation {
@@ -395,6 +401,7 @@ namespace TrafficManager.Traffic.Data {
 				case ExtPathMode.DrivingToKnownParkPos:
 				case ExtPathMode.DrivingToTarget:
 				case ExtPathMode.RequiresCarPath:
+				case ExtPathMode.RequiresDirectCarPathToTarget:
 				case ExtPathMode.ParkingFailed:
 					return ExtPathType.DrivingOnly;
 				case ExtPathMode.CalculatingWalkingPathToParkedCar:

--- a/TLM/TLM/Traffic/Data/ExtCitizenInstance.cs
+++ b/TLM/TLM/Traffic/Data/ExtCitizenInstance.cs
@@ -147,7 +147,7 @@ namespace TrafficManager.Traffic.Data {
 			/// where possible transitions between different modes of transport happen as required (thus no search
 			/// for parking spaces is performed beforehand)
 			/// </summary>
-			RequiresDirectCarPathToTarget = 18,
+			RequiresMixedCarPathToTarget = 18,
 		}
 
 		public enum ExtParkingSpaceLocation {
@@ -401,7 +401,7 @@ namespace TrafficManager.Traffic.Data {
 				case ExtPathMode.DrivingToKnownParkPos:
 				case ExtPathMode.DrivingToTarget:
 				case ExtPathMode.RequiresCarPath:
-				case ExtPathMode.RequiresDirectCarPathToTarget:
+				case ExtPathMode.RequiresMixedCarPathToTarget:
 				case ExtPathMode.ParkingFailed:
 					return ExtPathType.DrivingOnly;
 				case ExtPathMode.CalculatingWalkingPathToParkedCar:

--- a/TLM/TLM/Traffic/Data/ExtCitizenInstance.cs
+++ b/TLM/TLM/Traffic/Data/ExtCitizenInstance.cs
@@ -328,10 +328,10 @@ namespace TrafficManager.Traffic.Data {
 			ReleaseReturnPath();
 
 			PathUnit.Position parkPathPos;
-			PathUnit.Position targetPathPos;
-			if (CustomPathManager.FindPathPositionWithSpiralLoop(parkPos, ItemClass.Service.Road, NetInfo.LaneType.Pedestrian, VehicleInfo.VehicleType.None, NetInfo.LaneType.None, VehicleInfo.VehicleType.None, false, false, GlobalConfig.Instance.ParkingAI.MaxBuildingToPedestrianLaneDistance, out parkPathPos) &&
-				CustomPathManager.FindPathPositionWithSpiralLoop(targetPos, ItemClass.Service.Road, NetInfo.LaneType.Pedestrian, VehicleInfo.VehicleType.None, NetInfo.LaneType.None, VehicleInfo.VehicleType.None, false, false, GlobalConfig.Instance.ParkingAI.MaxBuildingToPedestrianLaneDistance, out targetPathPos)) {
-
+			PathUnit.Position targetPathPos = default(PathUnit.Position);
+			bool foundParkPathPos = CustomPathManager.FindCitizenPathPosition(parkPos, NetInfo.LaneType.Pedestrian, VehicleInfo.VehicleType.None, false, false, out parkPathPos);
+			bool foundTargetPathPos = foundParkPathPos && CustomPathManager.FindCitizenPathPosition(targetPos, NetInfo.LaneType.Pedestrian, VehicleInfo.VehicleType.None, false, false, out targetPathPos);
+			if (foundParkPathPos && foundTargetPathPos) {
 				PathUnit.Position dummyPathPos = default(PathUnit.Position);
 				uint pathId;
 				PathCreationArgs args;
@@ -366,13 +366,18 @@ namespace TrafficManager.Traffic.Data {
 					returnPathId = pathId;
 					returnPathState = ExtPathState.Calculating;
 					return true;
-				}
-			}
-
+				} else {
 #if DEBUG
-			if (debug)
-				Log._Debug($"ExtCitizenInstance.CalculateReturnPath: Could not find path position(s) for either the parking position or target position of citizen instance {instanceId}.");
+					if (debug)
+						Log._Debug($"ExtCitizenInstance.CalculateReturnPath: Could not create return path for citizen instance {instanceId}");
 #endif
+				}
+			} else {
+#if DEBUG
+				if (debug)
+					Log._Debug($"ExtCitizenInstance.CalculateReturnPath: Could not find path position(s) for either the parking position or target position of citizen instance {instanceId}: foundParkPathPos={foundParkPathPos} foundTargetPathPos={foundTargetPathPos}");
+#endif
+			}
 
 			return false;
 		}


### PR DESCRIPTION
Fixes #218 

- 1st issue: Before, cars that could not compute a path to a parking spot near their destination (either because no parking spaces exist or the destination is unreachable by car) they despawned. Now, they perform another "mixed" path-finding where usage of public transport and walking is allowed.
  - This change affects all direct car paths (without pre-queried parking spaces).
  - The CustomCarAI was modified to handle soft path calculation states (ExtSoftPathState)
  - AdvancedParkingManager now contains a new method `OnCarPathFindFailure` (similar to `OnCitizenPathFindFailure`) that decides whether path-finding may be repeated.
- 2nd issue: Tourist cars despawned because the Parking AI assumed that they reached an outside connection. The logic to determine whether the source/target is an outside connection has been improved.
- 3rd issue: (Mixed) car paths to pedestrian areas could not be calculated successfully because return path calculation did not consider beautification segments. This has been fixed.
- 4th issue: Return paths ended at the vehicle's last frame position which was incorrect. Now, return paths end at the final stop position of the vehicle.
- 5th issue: Soft path-find errors made the `SimulationStep` method exit. This caused citizens and cars to jump around for a short moment. Now, when a soft path-find error occurs, the simulation step runs nevertheless in order to update target positions and frame data correctly.
- 6th issue: Traffic measurement was performed even if cars were not spawned. This has been fixed.