### PR TITLE
Update incompatible_mods.txt

### DIFF
--- a/TLM/TLM/Resources/incompatible_mods.txt
+++ b/TLM/TLM/Resources/incompatible_mods.txt
@@ -44,3 +44,4 @@
 408209297;Extended Road Upgrade
 417926819;Road Assistant
 631930385;Realistic Vehicle Speeds
+877950833;Vanilla Trees Remover


### PR DESCRIPTION
Fixes #271

The "Vanilla Trees Remover" mod is known to cause issues with mod options for TM:PE and other mods:

* Completely blank options screen
* Or options for a different mod (usually one directly above or below in the mod list) are shown

TPB is aware of the issue for some time, but mod has not been fixed - so I've added it to list of incompatible mods.