### PR TITLE
Updated changelogs for 10.19 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 ﻿# Cities: Skylines - Traffic Manager: *President Edition* [![Discord](https://img.shields.io/discord/545065285862948894.svg)](https://discord.gg/faKUnST)
 
 # Changelog
+10.19, 20/04/2019
+- Bugfix: Mod options overlapping issue (#250, #266). 
+- Added: Japanese language (thanks mashitaro) (#258). 
+- Update: Chinese language (thanks Emphasia) (#285, #286). 
+- Update: "Vanilla Trees Remover" as incompatible mod (it breaks mod options screen) (#271, #290). 
+- Update: Moved "Delete" step button on timed traffic lights (#283, #285). 
+- Update: Mod incompatibility checker can now be disabled, or skip disabled mods (#264, #284, #286). 
+
 10.18, 29/03/2019
 - Bugfix: Parking AI: Cars do not spawn at outside connections (#245)
 - Bugfix: Trams perform turns on red (#248)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Traffic Manager: *President Edition* [![Steam](https://img.shields.io/endpoint.svg?url=https://shieldsio-steam-workshop.jross.me/583429740)](https://steamcommunity.com/sharedfiles/filedetails/?id=583429740) [![Discord](https://img.shields.io/discord/545065285862948894.svg?logo=discord&logoColor=F5F5F5)](https://discord.gg/faKUnST) [![Build status](https://ci.appveyor.com/api/projects/status/dehkvuxk8b3h66e7/branch/master?svg=true)](https://ci.appveyor.com/project/krzychu124/cities-skylines-traffic-manager-president-edition/branch/master)
+﻿# Traffic Manager: *President Edition* [![Steam](https://img.shields.io/endpoint.svg?url=https://shieldsio-steam-workshop.jross.me/583429740)](https://steamcommunity.com/sharedfiles/filedetails/?id=583429740) [![Discord](https://img.shields.io/discord/545065285862948894.svg?logo=discord&logoColor=F5F5F5)](https://discord.gg/faKUnST) [![Build status](https://ci.appveyor.com/api/projects/status/dehkvuxk8b3h66e7/branch/master?svg=true)](https://ci.appveyor.com/project/krzychu124/cities-skylines-traffic-manager-president-edition/branch/master)
 
 A mod for **Cities: Skylines** that gives you more control over road and rail traffic in your city.
 
@@ -22,10 +22,13 @@ A mod for **Cities: Skylines** that gives you more control over road and rail tr
 * Clear traffic, stuck cims, etc.
 
 # Changelog
-### [10.18](https://github.com/krzychu124/Cities-Skylines-Traffic-Manager-President-Edition/compare/10.17...10.18), 29/03/2019
-- Bugfix: Parking AI: Cars do not spawn at outside connections (#245)
-- Bugfix: Trams perform turns on red (#248)
-- Update: Service Radius Adjuster mod by Egi removed from incompatible mods list (#255)
+### [10.19](https://github.com/krzychu124/Cities-Skylines-Traffic-Manager-President-Edition/compare/10.18...10.18), 20/04/2019
+- Bugfix: Mod options overlapping issue (#250, #266). 
+- Added: Japanese language (thanks mashitaro) (#258). 
+- Update: Chinese language (thanks Emphasia) (#285, #286). 
+- Update: "Vanilla Trees Remover" as incompatible mod (it breaks mod options screen) (#271, #290). 
+- Update: Moved "Delete" step button on timed traffic lights (#283, #285). 
+- Update: Mod incompatibility checker can now be disabled, or skip disabled mods (#264, #284, #286). 
 
 See [Full Changelog](https://github.com/krzychu124/Cities-Skylines-Traffic-Manager-President-Edition/blob/master/CHANGELOG.md) for details of earlier releases.
 


### PR DESCRIPTION
Updated readme.md and changelog.md files for 10.19 release:

- Bugfix: Mod options overlapping issue (#250, #266). 
- Added: Japanese language (thanks mashitaro) (#258). 
- Update: Chinese language (thanks Emphasia) (#285, #286). 
- Update: "Vanilla Trees Remover" as incompatible mod (it breaks mod options screen) (#271, #290). 
- Update: Moved "Delete" step button on timed traffic lights (#283, #285). 
- Update: Mod incompatibility checker can now be disabled, or skip disabled mods (#264, #284, #286). 
