### PR TITLE
Update incompatible_mods.txt - Fixes #331

### DIFF
--- a/TLM/TLM/Resources/incompatible_mods.txt
+++ b/TLM/TLM/Resources/incompatible_mods.txt
@@ -44,4 +44,3 @@
 408209297;Extended Road Upgrade
 417926819;Road Assistant
 631930385;Realistic Vehicle Speeds
-877950833;Vanilla Trees Remover


### PR DESCRIPTION
Vanilla Trees Remover mod no longer breaks mod options screen

~~(Leaving this as Draft until the VTR mod is updated in Workshop)~~