### PR TITLE
No lane changes at toll boothes

### DIFF
--- a/TLM/TLM/Custom/AI/CustomVehicleAI.cs
+++ b/TLM/TLM/Custom/AI/CustomVehicleAI.cs
@@ -202,66 +202,54 @@ namespace TrafficManager.Custom.AI {
 				// find next lane (emergency vehicles / dynamic lane selection)
 				int bestLaneIndex = nextPathPos.m_lane;
 				if ((vehicleData.m_flags & Vehicle.Flags.Emergency2) != (Vehicle.Flags)0) {
+#if ROUTING
+					bestLaneIndex = VehicleBehaviorManager.Instance.FindBestEmergencyLane(vehicleID, ref vehicleData, ref VehicleStateManager.Instance.VehicleStates[vehicleID], curLaneId, currentPosition, curSegmentInfo, nextPathPos, nextSegmentInfo);
+#else
+					// stock procedure for emergency vehicles on duty
 					bestLaneIndex = FindBestLane(vehicleID, ref vehicleData, nextPathPos);
-				} else {
+#endif
+				} else if (VehicleBehaviorManager.Instance.MayFindBestLane(vehicleID, ref vehicleData, ref VehicleStateManager.Instance.VehicleStates[vehicleID])) {
 					// NON-STOCK CODE START
 					if (firstIter &&
 						this.m_info.m_vehicleType == VehicleInfo.VehicleType.Car &&
 						!this.m_info.m_isLargeVehicle
 					) {
-						bool mayFindBestLane = false;
-#if BENCHMARK
-						using (var bm = new Benchmark(null, "MayFindBestLane")) {
-#endif
-							mayFindBestLane = VehicleBehaviorManager.Instance.MayFindBestLane(vehicleID, ref vehicleData, ref VehicleStateManager.Instance.VehicleStates[vehicleID]);
-#if BENCHMARK
-						}
-#endif
+						uint next2PathId = nextPathId;
+						int next2PathPosIndex = nextCoarsePathPosIndex;
+						bool next2Invalid;
+						PathUnit.Position next2PathPos;
+						NetInfo next2SegmentInfo = null;
+						PathUnit.Position next3PathPos;
+						NetInfo next3SegmentInfo = null;
+						PathUnit.Position next4PathPos;
+						if (PathUnit.GetNextPosition(ref next2PathId, ref next2PathPosIndex, out next2PathPos, out next2Invalid)) {
+							next2SegmentInfo = netManager.m_segments.m_buffer[(int)next2PathPos.m_segment].Info;
 
-						if (mayFindBestLane) {
-							uint next2PathId = nextPathId;
-							int next2PathPosIndex = nextCoarsePathPosIndex;
-							bool next2Invalid;
-							PathUnit.Position next2PathPos;
-							NetInfo next2SegmentInfo = null;
-							PathUnit.Position next3PathPos;
-							NetInfo next3SegmentInfo = null;
-							PathUnit.Position next4PathPos;
-							if (PathUnit.GetNextPosition(ref next2PathId, ref next2PathPosIndex, out next2PathPos, out next2Invalid)) {
-								next2SegmentInfo = netManager.m_segments.m_buffer[(int)next2PathPos.m_segment].Info;
+							uint next3PathId = next2PathId;
+							int next3PathPosIndex = next2PathPosIndex;
+							bool next3Invalid;
+							if (PathUnit.GetNextPosition(ref next3PathId, ref next3PathPosIndex, out next3PathPos, out next3Invalid)) {
+								next3SegmentInfo = netManager.m_segments.m_buffer[(int)next3PathPos.m_segment].Info;
 
-								uint next3PathId = next2PathId;
-								int next3PathPosIndex = next2PathPosIndex;
-								bool next3Invalid;
-								if (PathUnit.GetNextPosition(ref next3PathId, ref next3PathPosIndex, out next3PathPos, out next3Invalid)) {
-									next3SegmentInfo = netManager.m_segments.m_buffer[(int)next3PathPos.m_segment].Info;
-
-									uint next4PathId = next3PathId;
-									int next4PathPosIndex = next3PathPosIndex;
-									bool next4Invalid;
-									if (!PathUnit.GetNextPosition(ref next4PathId, ref next4PathPosIndex, out next4PathPos, out next4Invalid)) {
-										next4PathPos = default(PathUnit.Position);
-									}
-								} else {
-									next3PathPos = default(PathUnit.Position);
+								uint next4PathId = next3PathId;
+								int next4PathPosIndex = next3PathPosIndex;
+								bool next4Invalid;
+								if (!PathUnit.GetNextPosition(ref next4PathId, ref next4PathPosIndex, out next4PathPos, out next4Invalid)) {
 									next4PathPos = default(PathUnit.Position);
 								}
 							} else {
-								next2PathPos = default(PathUnit.Position);
 								next3PathPos = default(PathUnit.Position);
 								next4PathPos = default(PathUnit.Position);
 							}
-
-#if BENCHMARK
-							using (var bm = new Benchmark(null, "FindBestLane")) {
-#endif
-								bestLaneIndex = VehicleBehaviorManager.Instance.FindBestLane(vehicleID, ref vehicleData, ref VehicleStateManager.Instance.VehicleStates[vehicleID], curLaneId, currentPosition, curSegmentInfo, nextPathPos, nextSegmentInfo, next2PathPos, next2SegmentInfo, next3PathPos, next3SegmentInfo, next4PathPos);
-#if BENCHMARK
-							}
-#endif
+						} else {
+							next2PathPos = default(PathUnit.Position);
+							next3PathPos = default(PathUnit.Position);
+							next4PathPos = default(PathUnit.Position);
 						}
-						// NON-STOCK CODE END
+
+						bestLaneIndex = VehicleBehaviorManager.Instance.FindBestLane(vehicleID, ref vehicleData, ref VehicleStateManager.Instance.VehicleStates[vehicleID], curLaneId, currentPosition, curSegmentInfo, nextPathPos, nextSegmentInfo, next2PathPos, next2SegmentInfo, next3PathPos, next3SegmentInfo, next4PathPos);
 					}
+					// NON-STOCK CODE END
 				}
 
 				// update lane index

--- a/TLM/TLM/Manager/IVehicleBehaviorManager.cs
+++ b/TLM/TLM/Manager/IVehicleBehaviorManager.cs
@@ -47,6 +47,21 @@ namespace TrafficManager.Manager {
 		int FindBestLane(ushort vehicleId, ref Vehicle vehicleData, ref VehicleState vehicleState, uint currentLaneId, PathUnit.Position currentPathPos, NetInfo currentSegInfo, PathUnit.Position next1PathPos, NetInfo next1SegInfo, PathUnit.Position next2PathPos, NetInfo next2SegInfo, PathUnit.Position next3PathPos, NetInfo next3SegInfo, PathUnit.Position next4PathPos);
 
 		/// <summary>
+		/// Identifies the best lane to take on the next segment (for emergency vehicles on duty).
+		/// Note that this method does not require Advanced AI and/or DLS to be active.
+		/// </summary>
+		/// <param name="vehicleId">queried vehicle id</param>
+		/// <param name="vehicleData">vehicle data</param>
+		/// <param name="vehicleState">vehicle state</param>
+		/// <param name="currentLaneId">current lane id</param>
+		/// <param name="currentPathPos">current path position</param>
+		/// <param name="currentSegInfo">current segment info</param>
+		/// <param name="nextPathPos">next path position</param>
+		/// <param name="nextSegInfo">next segment info</param>
+		/// <returns>target position lane index</returns>
+		int FindBestEmergencyLane(ushort vehicleId, ref Vehicle vehicleData, ref VehicleState vehicleState, uint currentLaneId, PathUnit.Position currentPathPos, NetInfo currentSegInfo, PathUnit.Position nextPathPos, NetInfo nextSegInfo);
+
+		/// <summary>
 		/// Determines if the given vehicle is allowed to find an alternative lane.
 		/// </summary>
 		/// <param name="vehicleId">queried vehicle</param>

--- a/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
+++ b/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
@@ -1453,6 +1453,132 @@ namespace TrafficManager.Manager.Impl {
 			return next1PathPos.m_lane;
 		}
 
+		public int FindBestEmergencyLane(ushort vehicleId, ref Vehicle vehicleData, ref VehicleState vehicleState, uint currentLaneId, PathUnit.Position currentPathPos, NetInfo currentSegInfo, PathUnit.Position nextPathPos, NetInfo nextSegInfo) {
+			try {
+				GlobalConfig conf = GlobalConfig.Instance;
+#if DEBUG
+				bool debug = false;
+				if (conf.Debug.Switches[17]) {
+					ushort nodeId = Services.NetService.GetSegmentNodeId(currentPathPos.m_segment, currentPathPos.m_offset < 128);
+					debug = (conf.Debug.VehicleId == 0 || conf.Debug.VehicleId == vehicleId) && (conf.Debug.NodeId == 0 || conf.Debug.NodeId == nodeId);
+				}
+
+				if (debug) {
+					Log._Debug($"VehicleBehaviorManager.FindBestEmergencyLane({vehicleId}): currentLaneId={currentLaneId}, currentPathPos=[seg={currentPathPos.m_segment}, lane={currentPathPos.m_lane}, off={currentPathPos.m_offset}] nextPathPos=[seg={nextPathPos.m_segment}, lane={nextPathPos.m_lane}, off={nextPathPos.m_offset}]");
+				}
+#endif
+
+				// cur -> next
+				float curPosition = 0f;
+				if (currentPathPos.m_lane < currentSegInfo.m_lanes.Length) {
+					curPosition = currentSegInfo.m_lanes[currentPathPos.m_lane].m_position;
+				}
+				float vehicleLength = 1f + vehicleState.totalLength;
+				bool startNode = currentPathPos.m_offset < 128;
+				uint currentFwdRoutingIndex = RoutingManager.Instance.GetLaneEndRoutingIndex(currentLaneId, startNode);
+
+#if DEBUG
+				if (currentFwdRoutingIndex >= RoutingManager.Instance.laneEndForwardRoutings.Length) {
+					Log.Error($"VehicleBehaviorManager.FindBestEmergencyLane({vehicleId}): Invalid array index: currentFwdRoutingIndex={currentFwdRoutingIndex}, RoutingManager.Instance.laneEndForwardRoutings.Length={RoutingManager.Instance.laneEndForwardRoutings.Length} (currentLaneId={currentLaneId}, startNode={startNode})");
+				}
+#endif
+
+				if (!RoutingManager.Instance.laneEndForwardRoutings[currentFwdRoutingIndex].routed) {
+#if DEBUG
+					if (debug) {
+						Log._Debug($"VehicleBehaviorManager.FindBestEmergencyLane({vehicleId}): No forward routing for next path position available.");
+					}
+#endif
+					return nextPathPos.m_lane;
+				}
+
+				LaneTransitionData[] currentFwdTransitions = RoutingManager.Instance.laneEndForwardRoutings[currentFwdRoutingIndex].transitions;
+
+				if (currentFwdTransitions == null) {
+#if DEBUG
+					if (debug) {
+						Log._Debug($"VehicleBehaviorManager.FindBestEmergencyLane({vehicleId}): No forward transitions found for current lane {currentLaneId} at startNode {startNode}.");
+					}
+#endif
+					return nextPathPos.m_lane;
+				}
+
+#if DEBUG
+				if (debug) {
+					Log._Debug($"VehicleBehaviorManager.FindBestEmergencyLane({vehicleId}): Starting lane-finding algorithm now. vehicleLength={vehicleLength}");
+				}
+#endif
+
+				float minCost = float.MaxValue;
+				byte bestNextLaneIndex = nextPathPos.m_lane;
+				for (int i = 0; i < currentFwdTransitions.Length; ++i) {
+					if (currentFwdTransitions[i].segmentId != nextPathPos.m_segment) {
+						continue;
+					}
+
+					if (!(
+						currentFwdTransitions[i].type == LaneEndTransitionType.Default ||
+						currentFwdTransitions[i].type == LaneEndTransitionType.LaneConnection ||
+						currentFwdTransitions[i].type == LaneEndTransitionType.Relaxed
+					)) {
+						continue;
+					}
+
+					if (!VehicleRestrictionsManager.Instance.MayUseLane(vehicleState.vehicleType, nextPathPos.m_segment, currentFwdTransitions[i].laneIndex, nextSegInfo)) {
+#if DEBUG
+						if (debug) {
+							Log._Debug($"VehicleBehaviorManager.FindBestEmergencyLane({vehicleId}): Skipping current transition {currentFwdTransitions[i]} (vehicle restrictions)");
+						}
+#endif
+						continue;
+					}
+
+					NetInfo.Lane nextLaneInfo = nextSegInfo.m_lanes[currentFwdTransitions[i].laneIndex];
+
+					/*
+					 * Check reserved space on next lane
+					 */
+#if DEBUG
+					if (debug) {
+						Log._Debug($"VehicleBehaviorManager.FindBestEmergencyLane({vehicleId}): Checking for traffic on next lane id={currentFwdTransitions[i].laneId}.");
+					}
+#endif
+
+					Services.NetService.ProcessLane(currentFwdTransitions[i].laneId, (uint nextLaneId, ref NetLane nextLane) => {
+						// similar to stock code in VehicleAI.FindBestLane
+						float cost = nextLane.GetReservedSpace();
+						if (currentFwdTransitions[i].laneIndex == nextPathPos.m_lane) {
+							cost -= vehicleLength;
+						}
+
+						cost += Mathf.Abs(curPosition - nextLaneInfo.m_position) * 0.1f;
+
+						if (cost < minCost) {
+							minCost = cost;
+							bestNextLaneIndex = currentFwdTransitions[i].laneIndex;
+
+#if DEBUG
+							if (debug) {
+								Log._Debug($"VehicleBehaviorManager.FindBestEmergencyLane({vehicleId}): Found better lane: bestNextLaneIndex={bestNextLaneIndex}, minCost={minCost}");
+							}
+#endif
+						}
+						return true;
+					});
+				} // for each forward transition
+
+#if DEBUG
+				if (debug) {
+					Log._Debug($"VehicleBehaviorManager.FindBestEmergencyLane({vehicleId}): Best lane identified: bestNextLaneIndex={bestNextLaneIndex}, minCost={minCost}");
+				}
+#endif
+				return bestNextLaneIndex;
+			} catch (Exception e) {
+				Log.Error($"VehicleBehaviorManager.FindBestEmergencyLane({vehicleId}): Exception occurred: {e}");
+			}
+			return nextPathPos.m_lane;
+		}
+
 		public bool MayFindBestLane(ushort vehicleId, ref Vehicle vehicleData, ref VehicleState vehicleState) {
 			GlobalConfig conf = GlobalConfig.Instance;
 #if DEBUG


### PR DESCRIPTION
- Regular and emergency vehicles do not change lanes at toll booths anymore.
- The old erroneous solution (checking for lanes with "Merge" flag) was removed.
- The new solution checks whether the transit node belongs to a toll booth. If that's the case lane transitions that involve lane changes are not generated anymore.

Fixes #225 