### PR TITLE
Minor fixes: Saving/Loading junction restrictions, UI overlay, Reset stuck cims

### DIFF
--- a/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
@@ -707,7 +707,7 @@ namespace TrafficManager.Manager.Impl {
 									SetNearTurnOnRedAllowed(segNodeConf.segmentId, true, (bool)flags.turnOnRedAllowed);
 								}
 
-								if (flags.farTurnOnRedAllowed != null && IsNearTurnOnRedAllowedConfigurable(segNodeConf.segmentId, true, ref node)) {
+								if (flags.farTurnOnRedAllowed != null && IsFarTurnOnRedAllowedConfigurable(segNodeConf.segmentId, true, ref node)) {
 									SetFarTurnOnRedAllowed(segNodeConf.segmentId, true, (bool)flags.farTurnOnRedAllowed);
 								}
 
@@ -752,11 +752,11 @@ namespace TrafficManager.Manager.Impl {
 									SetPedestrianCrossingAllowed(segNodeConf.segmentId, false, (bool)flags.pedestrianCrossingAllowed);
 								}
 
-								if (flags.turnOnRedAllowed != null) {
+								if (flags.turnOnRedAllowed != null && IsNearTurnOnRedAllowedConfigurable(segNodeConf.segmentId, false, ref node)) {
 									SetNearTurnOnRedAllowed(segNodeConf.segmentId, false, (bool)flags.turnOnRedAllowed);
 								}
 
-								if (flags.farTurnOnRedAllowed != null) {
+								if (flags.farTurnOnRedAllowed != null && IsFarTurnOnRedAllowedConfigurable(segNodeConf.segmentId, false, ref node)) {
 									SetFarTurnOnRedAllowed(segNodeConf.segmentId, false, (bool)flags.farTurnOnRedAllowed);
 								}
 								return true;

--- a/TLM/TLM/Manager/Impl/UtilityManager.cs
+++ b/TLM/TLM/Manager/Impl/UtilityManager.cs
@@ -93,8 +93,12 @@ namespace TrafficManager.Manager.Impl {
 		public void ResetStuckEntities() {
 			Log.Info($"UtilityManager.RemoveStuckEntities() called.");
 
-			Log.Info($"UtilityManager.RemoveStuckEntities(): Pausing simulation.");
-			Singleton<SimulationManager>.instance.ForcedSimulationPaused = true;
+			bool wasPaused = Singleton<SimulationManager>.instance.ForcedSimulationPaused;
+
+			if (!wasPaused) {
+				Log.Info($"UtilityManager.RemoveStuckEntities(): Pausing simulation.");
+				Singleton<SimulationManager>.instance.ForcedSimulationPaused = true;
+			}
 
 			Log.Info($"UtilityManager.RemoveStuckEntities(): Waiting for all paths.");
 			Singleton<PathManager>.instance.WaitForAllPaths();
@@ -150,8 +154,10 @@ namespace TrafficManager.Manager.Impl {
 				}
 			}
 
-			Log.Info($"UtilityManager.RemoveStuckEntities(): Unpausing simulation.");
-			Singleton<SimulationManager>.instance.ForcedSimulationPaused = false;
+			if (!wasPaused) {
+				Log.Info($"UtilityManager.RemoveStuckEntities(): Unpausing simulation.");
+				Singleton<SimulationManager>.instance.ForcedSimulationPaused = false;
+			}
 		}
 	}
 }

--- a/TLM/TLM/State/Options.cs
+++ b/TLM/TLM/State/Options.cs
@@ -947,7 +947,7 @@ namespace TrafficManager.State {
 			}
 
 			Log._Debug($"allowLaneChangesWhileGoingStraight changed to {newValue}");
-			allowLaneChangesWhileGoingStraight = newValue;
+			setAllowLaneChangesWhileGoingStraight(newValue);
 		}
 
 		private static void onTrafficLightPriorityRulesChanged(bool newValue) {
@@ -1298,6 +1298,7 @@ namespace TrafficManager.State {
 			if (allowUTurnsToggle != null)
 				allowUTurnsToggle.isChecked = value;
 			Constants.ManagerFactory.JunctionRestrictionsManager.UpdateAllDefaults();
+			UIBase.GetTrafficManagerTool(false)?.InitializeSubTools();
 		}
 
 		public static void setAllowNearTurnOnRed(bool newValue) {
@@ -1305,6 +1306,7 @@ namespace TrafficManager.State {
 			if (allowNearTurnOnRedToggle != null)
 				allowNearTurnOnRedToggle.isChecked = newValue;
 			Constants.ManagerFactory.JunctionRestrictionsManager.UpdateAllDefaults();
+			UIBase.GetTrafficManagerTool(false)?.InitializeSubTools();
 		}
 
 		public static void setAllowFarTurnOnRed(bool newValue) {
@@ -1312,6 +1314,7 @@ namespace TrafficManager.State {
 			if (allowFarTurnOnRedToggle != null)
 				allowFarTurnOnRedToggle.isChecked = newValue;
 			Constants.ManagerFactory.JunctionRestrictionsManager.UpdateAllDefaults();
+			UIBase.GetTrafficManagerTool(false)?.InitializeSubTools();
 		}
 
 		public static void setAllowLaneChangesWhileGoingStraight(bool value) {
@@ -1319,6 +1322,7 @@ namespace TrafficManager.State {
 			if (allowLaneChangesWhileGoingStraightToggle != null)
 				allowLaneChangesWhileGoingStraightToggle.isChecked = value;
 			Constants.ManagerFactory.JunctionRestrictionsManager.UpdateAllDefaults();
+			UIBase.GetTrafficManagerTool(false)?.InitializeSubTools();
 		}
 
 		public static void setAllowEnterBlockedJunctions(bool value) {
@@ -1326,6 +1330,7 @@ namespace TrafficManager.State {
 			if (allowEnterBlockedJunctionsToggle != null)
 				allowEnterBlockedJunctionsToggle.isChecked = value;
 			Constants.ManagerFactory.JunctionRestrictionsManager.UpdateAllDefaults();
+			UIBase.GetTrafficManagerTool(false)?.InitializeSubTools();
 		}
 
 		public static void setTrafficLightPriorityRules(bool value) {


### PR DESCRIPTION
- Fixed minor issues regarding saving/loading junction restrictions
- Bugfix: Changes of default junction restrictions are not reflected in the UI overlay
- Bugfix: Resetting stuck cims unpauses the simulation (#351)

Fixes #351 