### PR TITLE
StyleCop/Resharper suggestions for Traffic/Data/VehicleState.cs

### DIFF
--- a/TLM/TLM/Custom/AI/CustomCarAI.cs
+++ b/TLM/TLM/Custom/AI/CustomCarAI.cs
@@ -61,7 +61,7 @@ namespace TrafficManager.Custom.AI {
 				using (var bm = new Benchmark(null, "UpdateCarPathState")) {
 #endif
 				finalPathState = ExtCitizenInstance.ConvertPathStateToSoftPathState(mainPathState);
-				if (Options.prohibitPocketCars && VehicleStateManager.Instance.VehicleStates[vehicleId].vehicleType == ExtVehicleType.PassengerCar) {
+				if (Options.prohibitPocketCars && VehicleStateManager.Instance.VehicleStates[vehicleId].VehicleType == ExtVehicleType.PassengerCar) {
 					ushort driverInstanceId = CustomPassengerCarAI.GetDriverInstanceId(vehicleId, ref vehicleData);
 					finalPathState = AdvancedParkingManager.Instance.UpdateCarPathState(vehicleId, ref vehicleData, ref Singleton<CitizenManager>.instance.m_instances.m_buffer[driverInstanceId], ref ExtCitizenInstanceManager.Instance.ExtInstances[driverInstanceId], mainPathState);
 

--- a/TLM/TLM/Manager/Impl/AdvancedParkingManager.cs
+++ b/TLM/TLM/Manager/Impl/AdvancedParkingManager.cs
@@ -195,7 +195,7 @@ namespace TrafficManager.Manager.Impl {
 				return ExtCitizenInstance.ConvertPathStateToSoftPathState(mainPathState);
 			}
 
-			if (VehicleStateManager.Instance.VehicleStates[vehicleId].vehicleType != ExtVehicleType.PassengerCar) {
+			if (VehicleStateManager.Instance.VehicleStates[vehicleId].VehicleType != ExtVehicleType.PassengerCar) {
 				// non-passenger cars are not handled
 #if DEBUG
 				if (debug)

--- a/TLM/TLM/Manager/Impl/TrafficPriorityManager.cs
+++ b/TLM/TLM/Manager/Impl/TrafficPriorityManager.cs
@@ -471,7 +471,7 @@ namespace TrafficManager.Manager.Impl {
 					}
 
 					// check next incoming vehicle
-					incomingVehicleId = vehStateManager.VehicleStates[incomingVehicleId].nextVehicleIdOnSegment;
+					incomingVehicleId = vehStateManager.VehicleStates[incomingVehicleId].NextVehicleIdOnSegment;
 				}
 			}
 #if DEBUG
@@ -490,11 +490,11 @@ namespace TrafficManager.Manager.Impl {
 			if (debug) {
 				Log._Debug($"TrafficPriorityManager.IsConflictingVehicle({vehicleId}, {incomingVehicleId}): Checking against other vehicle {incomingVehicleId}.");
 				Log._Debug($"TrafficPriorityManager.IsConflictingVehicle({vehicleId}, {incomingVehicleId}): TARGET is coming from seg. {curPos.m_segment}, start {startNode}, lane {curPos.m_lane}, going to seg. {nextPos.m_segment}, lane {nextPos.m_lane}");
-				Log._Debug($"TrafficPriorityManager.IsConflictingVehicle({vehicleId}, {incomingVehicleId}): INCOMING is coming from seg. {incomingState.currentSegmentId}, start {incomingState.currentStartNode}, lane {incomingState.currentLaneIndex}, going to seg. {incomingState.nextSegmentId}, lane {incomingState.nextLaneIndex}\nincoming state: {incomingState}");
+				Log._Debug($"TrafficPriorityManager.IsConflictingVehicle({vehicleId}, {incomingVehicleId}): INCOMING is coming from seg. {incomingState.CurrentSegmentId}, start {incomingState.IsCurrentStartNode}, lane {incomingState.CurrentLaneIndex}, going to seg. {incomingState.NextSegmentId}, lane {incomingState.NextLaneIndex}\nincoming state: {incomingState}");
 			}
 #endif
 
-			if ((incomingState.flags & VehicleState.Flags.Spawned) == VehicleState.Flags.None) {
+			if ((incomingState.VehicleFlags & VehicleState.Flags.Spawned) == VehicleState.Flags.None) {
 #if DEBUG
 				if (debug)
 					Log.Warning($"TrafficPriorityManager.IsConflictingVehicle({vehicleId}, {incomingVehicleId}): Incoming vehicle is not spawned.");
@@ -512,10 +512,10 @@ namespace TrafficManager.Manager.Impl {
 				return false;
 			}
 
-			ArrowDirection incomingToRelDir = incomingEndGeo.GetDirection(incomingState.nextSegmentId); // relative target direction of incoming vehicle
+			ArrowDirection incomingToRelDir = incomingEndGeo.GetDirection(incomingState.NextSegmentId); // relative target direction of incoming vehicle
 
 			if (incomingLights != null) {
-				ICustomSegmentLight incomingLight = incomingLights.GetCustomLight(incomingState.currentLaneIndex);
+				ICustomSegmentLight incomingLight = incomingLights.GetCustomLight(incomingState.CurrentLaneIndex);
 #if DEBUG
 				if (debug)
 					Log._Debug($"TrafficPriorityManager.IsConflictingVehicle({vehicleId}, {incomingVehicleId}): Detected traffic light. Incoming state ({incomingToRelDir}): {incomingLight.GetLightState(incomingToRelDir)}");
@@ -535,7 +535,7 @@ namespace TrafficManager.Manager.Impl {
 				if (incomingState.JunctionTransitState == VehicleJunctionTransitState.Approach ||
 					incomingState.JunctionTransitState == VehicleJunctionTransitState.Leave
 				) {
-					if ((incomingState.vehicleType & ExtVehicleType.RoadVehicle) != ExtVehicleType.None) {
+					if ((incomingState.VehicleType & ExtVehicleType.RoadVehicle) != ExtVehicleType.None) {
 						float incomingSqrSpeed = incomingVel.sqrMagnitude;
 						if (!incomingStateChangedRecently && incomingSqrSpeed <= GlobalConfig.Instance.PriorityRules.MaxStopVelocity) {
 #if DEBUG
@@ -661,7 +661,7 @@ namespace TrafficManager.Manager.Impl {
 #if DEBUG
 			if (debug) {
 				Log._Debug("");
-				Log._Debug($"  TrafficPriorityManager.HasVehiclePriority({vehicleId}, {incomingVehicleId}): *** Checking if vehicle {vehicleId} (main road = {onMain}) @ (seg. {curPos.m_segment}, start {startNode}, lane {curPos.m_lane}) -> (seg. {nextPos.m_segment}, lane {nextPos.m_lane}) has priority over {incomingVehicleId} (main road = {incomingOnMain}) @ (seg. {incomingState.currentSegmentId}, start {incomingState.currentStartNode}, lane {incomingState.currentLaneIndex}) -> (seg. {incomingState.nextSegmentId}, lane {incomingState.nextLaneIndex}).");
+				Log._Debug($"  TrafficPriorityManager.HasVehiclePriority({vehicleId}, {incomingVehicleId}): *** Checking if vehicle {vehicleId} (main road = {onMain}) @ (seg. {curPos.m_segment}, start {startNode}, lane {curPos.m_lane}) -> (seg. {nextPos.m_segment}, lane {nextPos.m_lane}) has priority over {incomingVehicleId} (main road = {incomingOnMain}) @ (seg. {incomingState.CurrentSegmentId}, start {incomingState.IsCurrentStartNode}, lane {incomingState.CurrentLaneIndex}) -> (seg. {incomingState.NextSegmentId}, lane {incomingState.NextLaneIndex}).");
             }
 #endif
 
@@ -674,7 +674,7 @@ namespace TrafficManager.Manager.Impl {
 				return true;
 			}
 
-			if (curPos.m_segment == incomingState.currentSegmentId) {
+			if (curPos.m_segment == incomingState.CurrentSegmentId) {
 				// both vehicles are coming from the same segment. do not apply priority rules in this case.
 #if DEBUG
 				if (debug) {
@@ -726,7 +726,7 @@ namespace TrafficManager.Manager.Impl {
 			 * (1) COLLISION DETECTION
 			 */
 
-			bool sameTargets = nextPos.m_segment == incomingState.nextSegmentId;
+			bool sameTargets = nextPos.m_segment == incomingState.NextSegmentId;
 			bool wouldCollide = DetectCollision(debug, ref curPos, transitNodeId, startNode, ref nextPos, ref incomingState, targetToDir, incomingFromDir, incomingToRelDir, vehicleId, incomingVehicleId);
 
 			if (!wouldCollide) {
@@ -805,7 +805,7 @@ namespace TrafficManager.Manager.Impl {
 		public bool DetectCollision(bool debug, ref PathUnit.Position curPos, ushort transitNodeId, bool startNode, ref PathUnit.Position nextPos,
 			ref VehicleState incomingState, ArrowDirection targetToDir, ArrowDirection incomingFromDir, ArrowDirection incomingToRelDir, ushort vehicleId=0, ushort incomingVehicleId=0
 		) {
-			bool sameTargets = nextPos.m_segment == incomingState.nextSegmentId;
+			bool sameTargets = nextPos.m_segment == incomingState.NextSegmentId;
 			bool wouldCollide;
 			bool incomingIsLeaving = incomingState.JunctionTransitState == VehicleJunctionTransitState.Leave;
 			if (sameTargets) {
@@ -816,7 +816,7 @@ namespace TrafficManager.Manager.Impl {
 				}
 #endif
 
-				if (nextPos.m_lane == incomingState.nextLaneIndex) {
+				if (nextPos.m_lane == incomingState.NextLaneIndex) {
 					// both are going to the same lane: lane order is always incorrect
 #if DEBUG
 					if (debug) {
@@ -836,10 +836,10 @@ namespace TrafficManager.Manager.Impl {
 						case ArrowDirection.Turn:
 						default: // (should not happen)
 								 // target & incoming are going left: stay left
-							wouldCollide = !IsLaneOrderConflictFree(debug, nextPos.m_segment, transitNodeId, nextPos.m_lane, incomingState.nextLaneIndex); // stay left
+							wouldCollide = !IsLaneOrderConflictFree(debug, nextPos.m_segment, transitNodeId, nextPos.m_lane, incomingState.NextLaneIndex); // stay left
 #if DEBUG
 							if (debug) {
-								Log._Debug($"  TrafficPriorityManager.DetectCollision({vehicleId}, {incomingVehicleId}): Target is going {targetToDir}. Checking if lane {nextPos.m_lane} is LEFT to {incomingState.nextLaneIndex}. would collide? {wouldCollide}");
+								Log._Debug($"  TrafficPriorityManager.DetectCollision({vehicleId}, {incomingVehicleId}): Target is going {targetToDir}. Checking if lane {nextPos.m_lane} is LEFT to {incomingState.NextLaneIndex}. would collide? {wouldCollide}");
 							}
 #endif
 							break;
@@ -849,19 +849,19 @@ namespace TrafficManager.Manager.Impl {
 								case ArrowDirection.Left:
 								case ArrowDirection.Forward:
 									// target is going forward, incoming is coming from left/forward: stay right
-									wouldCollide = !IsLaneOrderConflictFree(debug, nextPos.m_segment, transitNodeId, incomingState.nextLaneIndex, nextPos.m_lane); // stay right
+									wouldCollide = !IsLaneOrderConflictFree(debug, nextPos.m_segment, transitNodeId, incomingState.NextLaneIndex, nextPos.m_lane); // stay right
 #if DEBUG
 									if (debug) {
-										Log._Debug($"  TrafficPriorityManager.DetectCollision({vehicleId}, {incomingVehicleId}): Target is going {targetToDir} and incoming is coming from {incomingFromDir}. Checking if lane {nextPos.m_lane} is RIGHT to {incomingState.nextLaneIndex}. would collide? {wouldCollide}");
+										Log._Debug($"  TrafficPriorityManager.DetectCollision({vehicleId}, {incomingVehicleId}): Target is going {targetToDir} and incoming is coming from {incomingFromDir}. Checking if lane {nextPos.m_lane} is RIGHT to {incomingState.NextLaneIndex}. would collide? {wouldCollide}");
 									}
 #endif
 									break;
 								case ArrowDirection.Right:
 									// target is going forward, incoming is coming from right: stay left
-									wouldCollide = !IsLaneOrderConflictFree(debug, nextPos.m_segment, transitNodeId, nextPos.m_lane, incomingState.nextLaneIndex); // stay left
+									wouldCollide = !IsLaneOrderConflictFree(debug, nextPos.m_segment, transitNodeId, nextPos.m_lane, incomingState.NextLaneIndex); // stay left
 #if DEBUG
 									if (debug) {
-										Log._Debug($"  TrafficPriorityManager.DetectCollision({vehicleId}, {incomingVehicleId}): Target is going {targetToDir} and incoming is coming from {incomingFromDir}. Checking if lane {nextPos.m_lane} is LEFT to {incomingState.nextLaneIndex}. would collide? {wouldCollide}");
+										Log._Debug($"  TrafficPriorityManager.DetectCollision({vehicleId}, {incomingVehicleId}): Target is going {targetToDir} and incoming is coming from {incomingFromDir}. Checking if lane {nextPos.m_lane} is LEFT to {incomingState.NextLaneIndex}. would collide? {wouldCollide}");
 									}
 #endif
 									break;
@@ -878,10 +878,10 @@ namespace TrafficManager.Manager.Impl {
 							break;
 						case ArrowDirection.Right:
 							// target is going right: stay right
-							wouldCollide = !IsLaneOrderConflictFree(debug, nextPos.m_segment, transitNodeId, incomingState.nextLaneIndex, nextPos.m_lane); // stay right
+							wouldCollide = !IsLaneOrderConflictFree(debug, nextPos.m_segment, transitNodeId, incomingState.NextLaneIndex, nextPos.m_lane); // stay right
 #if DEBUG
 							if (debug) {
-								Log._Debug($"  TrafficPriorityManager.DetectCollision({vehicleId}, {incomingVehicleId}): Target is going RIGHT. Checking if lane {nextPos.m_lane} is RIGHT to {incomingState.nextLaneIndex}. would collide? {wouldCollide}");
+								Log._Debug($"  TrafficPriorityManager.DetectCollision({vehicleId}, {incomingVehicleId}): Target is going RIGHT. Checking if lane {nextPos.m_lane} is RIGHT to {incomingState.NextLaneIndex}. would collide? {wouldCollide}");
 							}
 #endif
 							break;

--- a/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
+++ b/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
@@ -123,13 +123,13 @@ namespace TrafficManager.Manager.Impl {
 			}
 
 			if ((vehicleState.JunctionTransitState == VehicleJunctionTransitState.Stop || vehicleState.JunctionTransitState == VehicleJunctionTransitState.Blocked) &&
-				vehicleState.lastTransitStateUpdate >> VehicleState.JUNCTION_RECHECK_SHIFT >= Constants.ServiceFactory.SimulationService.CurrentFrameIndex >> VehicleState.JUNCTION_RECHECK_SHIFT) {
+				vehicleState.LastTransitStateUpdate >> VehicleState.JUNCTION_RECHECK_SHIFT >= Constants.ServiceFactory.SimulationService.CurrentFrameIndex >> VehicleState.JUNCTION_RECHECK_SHIFT) {
 				// reuse recent result
 				maxSpeed = 0f;
 				return false;
 			}
 
-			bool isRecklessDriver = vehicleState.recklessDriver;
+			bool isRecklessDriver = vehicleState.IsRecklessDriver;
 
 			var netManager = Singleton<NetManager>.instance;
 
@@ -185,7 +185,7 @@ namespace TrafficManager.Manager.Impl {
 					//using (var bm = new Benchmark(null, "CheckSpace")) {
 #endif
 					// check if there is enough space
-					var len = vehicleState.totalLength + 4f;
+					var len = vehicleState.TotalLength + 4f;
 					if (!netManager.m_lanes.m_buffer[laneID].CheckSpace(len)) {
 						var sufficientSpace = false;
 						if (nextPosition.m_segment != 0 && netManager.m_lanes.m_buffer[laneID].m_length < 30f) {
@@ -307,7 +307,7 @@ namespace TrafficManager.Manager.Impl {
 					if (
 						Options.turnOnRedEnabled &&
 						stopCar &&
-						(vehicleState.vehicleType & ExtVehicleType.RoadVehicle) != ExtVehicleType.None &&
+						(vehicleState.VehicleType & ExtVehicleType.RoadVehicle) != ExtVehicleType.None &&
 						sqrVelocity <= GlobalConfig.Instance.PriorityRules.MaxYieldVelocity * GlobalConfig.Instance.PriorityRules.MaxYieldVelocity &&
 						!isRecklessDriver
 					) {
@@ -419,23 +419,23 @@ namespace TrafficManager.Manager.Impl {
 								case PriorityType.Stop:
 #if DEBUG
 									if (debug)
-										Log._Debug($"VehicleBehaviorManager.MayChangeSegment({frontVehicleId}): STOP sign. waittime={vehicleState.waitTime}, sqrVelocity={sqrVelocity}");
+										Log._Debug($"VehicleBehaviorManager.MayChangeSegment({frontVehicleId}): STOP sign. waittime={vehicleState.WaitTime}, sqrVelocity={sqrVelocity}");
 #endif
 
 									maxSpeed = 0f;
 
-									if (vehicleState.waitTime < GlobalConfig.Instance.PriorityRules.MaxPriorityWaitTime) {
+									if (vehicleState.WaitTime < GlobalConfig.Instance.PriorityRules.MaxPriorityWaitTime) {
 #if DEBUG
 										if (debug)
-											Log._Debug($"VehicleBehaviorManager.MayChangeSegment({frontVehicleId}): Setting JunctionTransitState to STOP (wait) waitTime={vehicleState.waitTime}");
+											Log._Debug($"VehicleBehaviorManager.MayChangeSegment({frontVehicleId}): Setting JunctionTransitState to STOP (wait) waitTime={vehicleState.WaitTime}");
 #endif
 										vehicleState.JunctionTransitState = VehicleJunctionTransitState.Stop;
 
 										if (sqrVelocity <= GlobalConfig.Instance.PriorityRules.MaxStopVelocity * GlobalConfig.Instance.PriorityRules.MaxStopVelocity) {
-											vehicleState.waitTime++;
+											vehicleState.WaitTime++;
 
 											//float minStopWaitTime = Singleton<SimulationManager>.instance.m_randomizer.UInt32(3);
-											if (vehicleState.waitTime >= 2) {
+											if (vehicleState.WaitTime >= 2) {
 												if (Options.simAccuracy >= 4) {
 													vehicleState.JunctionTransitState = VehicleJunctionTransitState.Leave;
 												} else {
@@ -467,7 +467,7 @@ namespace TrafficManager.Manager.Impl {
 											if (debug)
 												Log._Debug($"VehicleBehaviorManager.MayChangeSegment({frontVehicleId}): Vehicle has come to a full stop.");
 #endif
-											vehicleState.waitTime = 0;
+											vehicleState.WaitTime = 0;
 											return false;
 										}
 									} else {
@@ -481,11 +481,11 @@ namespace TrafficManager.Manager.Impl {
 								case PriorityType.Yield:
 #if DEBUG
 									if (debug)
-										Log._Debug($"VehicleBehaviorManager.MayChangeSegment({frontVehicleId}): YIELD sign. waittime={vehicleState.waitTime}");
+										Log._Debug($"VehicleBehaviorManager.MayChangeSegment({frontVehicleId}): YIELD sign. waittime={vehicleState.WaitTime}");
 #endif
 
-									if (vehicleState.waitTime < GlobalConfig.Instance.PriorityRules.MaxPriorityWaitTime) {
-										vehicleState.waitTime++;
+									if (vehicleState.WaitTime < GlobalConfig.Instance.PriorityRules.MaxPriorityWaitTime) {
+										vehicleState.WaitTime++;
 #if DEBUG
 										if (debug)
 											Log._Debug($"VehicleBehaviorManager.MayChangeSegment({frontVehicleId}): Setting JunctionTransitState to STOP (wait)");
@@ -517,7 +517,7 @@ namespace TrafficManager.Manager.Impl {
 										} else {
 #if DEBUG
 											if (debug)
-												Log._Debug($"VehicleBehaviorManager.MayChangeSegment({frontVehicleId}): Vehicle has not yet reached yield speed (reduce {sqrVelocity} by {vehicleState.reduceSqrSpeedByValueToYield})");
+												Log._Debug($"VehicleBehaviorManager.MayChangeSegment({frontVehicleId}): Vehicle has not yet reached yield speed (reduce {sqrVelocity} by {vehicleState.ReduceSqrSpeedByValueToYield})");
 #endif
 
 											// vehicle has not yet reached yield speed
@@ -536,15 +536,15 @@ namespace TrafficManager.Manager.Impl {
 								default:
 #if DEBUG
 									if (debug)
-										Log._Debug($"VehicleBehaviorManager.MayChangeSegment({frontVehicleId}): MAIN sign. waittime={vehicleState.waitTime}");
+										Log._Debug($"VehicleBehaviorManager.MayChangeSegment({frontVehicleId}): MAIN sign. waittime={vehicleState.WaitTime}");
 #endif
 									maxSpeed = 0f;
 
 									if (Options.simAccuracy == 4)
 										return true;
 
-									if (vehicleState.waitTime < GlobalConfig.Instance.PriorityRules.MaxPriorityWaitTime) {
-										vehicleState.waitTime++;
+									if (vehicleState.WaitTime < GlobalConfig.Instance.PriorityRules.MaxPriorityWaitTime) {
+										vehicleState.WaitTime++;
 #if DEBUG
 										if (debug)
 											Log._Debug($"VehicleBehaviorManager.MayChangeSegment({frontVehicleId}): Setting JunctionTransitState to STOP (wait)");
@@ -575,7 +575,7 @@ namespace TrafficManager.Manager.Impl {
 									}
 									return true;
 							}
-						} else if (sqrVelocity <= GlobalConfig.Instance.PriorityRules.MaxStopVelocity * GlobalConfig.Instance.PriorityRules.MaxStopVelocity && (vehicleState.vehicleType & ExtVehicleType.RoadVehicle) != ExtVehicleType.None) {
+						} else if (sqrVelocity <= GlobalConfig.Instance.PriorityRules.MaxStopVelocity * GlobalConfig.Instance.PriorityRules.MaxStopVelocity && (vehicleState.VehicleType & ExtVehicleType.RoadVehicle) != ExtVehicleType.None) {
 							// vehicle is not moving. reset allowance to leave junction
 #if DEBUG
 							if (debug)
@@ -694,7 +694,7 @@ namespace TrafficManager.Manager.Impl {
 		}
 
 		public uint GetTimedVehicleRand(ushort vehicleId) {
-			return (uint)(vehicleId % 2) * 50u + VehicleStateManager.Instance.VehicleStates[vehicleId].timedRand;
+			return (uint)(vehicleId % 2) * 50u + VehicleStateManager.Instance.VehicleStates[vehicleId].TimedRand;
 		}
 
 		public float ApplyRealisticSpeeds(float speed, ushort vehicleId, ref VehicleState state, VehicleInfo vehicleInfo) {
@@ -702,12 +702,12 @@ namespace TrafficManager.Manager.Impl {
 				float vehicleRand = 0.01f * (float)GetTimedVehicleRand(vehicleId);
 				if (vehicleInfo.m_isLargeVehicle) {
 					speed *= 0.75f + vehicleRand * 0.25f; // a little variance, 0.75 .. 1
-				} else if (state.recklessDriver) {
+				} else if (state.IsRecklessDriver) {
 					speed *= 1.1f + vehicleRand * 0.5f; // woohooo, 1.1 .. 1.6
 				} else {
 					speed *= 0.8f + vehicleRand * 0.5f; // a little variance, 0.8 .. 1.3
 				}
-			} else if (state.recklessDriver) {
+			} else if (state.IsRecklessDriver) {
 				speed *= 1.5f;
 			}
 			return speed;
@@ -744,11 +744,11 @@ namespace TrafficManager.Manager.Impl {
 					Log._Debug($"VehicleBehaviorManager.FindBestLane({vehicleId}): currentLaneId={currentLaneId}, currentPathPos=[seg={currentPathPos.m_segment}, lane={currentPathPos.m_lane}, off={currentPathPos.m_offset}] next1PathPos=[seg={next1PathPos.m_segment}, lane={next1PathPos.m_lane}, off={next1PathPos.m_offset}] next2PathPos=[seg={next2PathPos.m_segment}, lane={next2PathPos.m_lane}, off={next2PathPos.m_offset}] next3PathPos=[seg={next3PathPos.m_segment}, lane={next3PathPos.m_lane}, off={next3PathPos.m_offset}] next4PathPos=[seg={next4PathPos.m_segment}, lane={next4PathPos.m_lane}, off={next4PathPos.m_offset}]");
 				}
 #endif
-				if (!vehicleState.dlsReady) {
+				if (!vehicleState.IsDlsReady) {
 					vehicleState.UpdateDynamicLaneSelectionParameters();
 				}
 
-				if (vehicleState.lastAltLaneSelSegmentId == currentPathPos.m_segment) {
+				if (vehicleState.LastAltLaneSelSegmentId == currentPathPos.m_segment) {
 #if DEBUG
 					if (debug) {
 						Log._Debug($"VehicleBehaviorManager.FindBestLane({vehicleId}): Skipping alternative lane selection: Already calculated.");
@@ -756,13 +756,13 @@ namespace TrafficManager.Manager.Impl {
 #endif
 					return next1PathPos.m_lane;
 				}
-				vehicleState.lastAltLaneSelSegmentId = currentPathPos.m_segment;
+				vehicleState.LastAltLaneSelSegmentId = currentPathPos.m_segment;
 
-				bool recklessDriver = vehicleState.recklessDriver;
-				float maxReservedSpace = vehicleState.maxReservedSpace;
+				bool recklessDriver = vehicleState.IsRecklessDriver;
+				float maxReservedSpace = vehicleState.MaxReservedSpace;
 
 				// cur -> next1
-				float vehicleLength = 1f + vehicleState.totalLength;
+				float vehicleLength = 1f + vehicleState.TotalLength;
 				bool startNode = currentPathPos.m_offset < 128;
 				uint currentFwdRoutingIndex = RoutingManager.Instance.GetLaneEndRoutingIndex(currentLaneId, startNode);
 
@@ -846,7 +846,7 @@ namespace TrafficManager.Manager.Impl {
 						continue;
 					}
 
-					if (!VehicleRestrictionsManager.Instance.MayUseLane(vehicleState.vehicleType, next1PathPos.m_segment, currentFwdTransitions[i].laneIndex, next1SegInfo)) {
+					if (!VehicleRestrictionsManager.Instance.MayUseLane(vehicleState.VehicleType, next1PathPos.m_segment, currentFwdTransitions[i].laneIndex, next1SegInfo)) {
 #if DEBUG
 						if (debug) {
 							Log._Debug($"VehicleBehaviorManager.FindBestLane({vehicleId}): Skipping current transition {currentFwdTransitions[i]} (vehicle restrictions)");
@@ -902,7 +902,7 @@ namespace TrafficManager.Manager.Impl {
 								continue;
 							}
 
-							if (!VehicleRestrictionsManager.Instance.MayUseLane(vehicleState.vehicleType, next2PathPos.m_segment, next1FwdTransitions[j].laneIndex, next2SegInfo)) {
+							if (!VehicleRestrictionsManager.Instance.MayUseLane(vehicleState.VehicleType, next2PathPos.m_segment, next1FwdTransitions[j].laneIndex, next2SegInfo)) {
 #if DEBUG
 								if (debug) {
 									Log._Debug($"VehicleBehaviorManager.FindBestLane({vehicleId}): Skipping next1 transition {next1FwdTransitions[j]} (vehicle restrictions)");
@@ -955,7 +955,7 @@ namespace TrafficManager.Manager.Impl {
 										continue;
 									}
 
-									if (!VehicleRestrictionsManager.Instance.MayUseLane(vehicleState.vehicleType, next3PathPos.m_segment, next2FwdTransitions[k].laneIndex, next3SegInfo)) {
+									if (!VehicleRestrictionsManager.Instance.MayUseLane(vehicleState.VehicleType, next3PathPos.m_segment, next2FwdTransitions[k].laneIndex, next3SegInfo)) {
 #if DEBUG
 										if (debug) {
 											Log._Debug($"VehicleBehaviorManager.FindBestLane({vehicleId}): Skipping next2 transition {next2FwdTransitions[k]} (vehicle restrictions)");
@@ -1210,8 +1210,8 @@ namespace TrafficManager.Manager.Impl {
 
 					float relMeanSpeedInPercent = meanSpeed / (TrafficMeasurementManager.REF_REL_SPEED / TrafficMeasurementManager.REF_REL_SPEED_PERCENT_DENOMINATOR);
 					float randSpeed = 0f;
-					if (vehicleState.laneSpeedRandInterval > 0) {
-						randSpeed = Services.SimulationService.Randomizer.Int32((uint)vehicleState.laneSpeedRandInterval + 1u) - vehicleState.laneSpeedRandInterval / 2f;
+					if (vehicleState.LaneSpeedRandInterval > 0) {
+						randSpeed = Services.SimulationService.Randomizer.Int32((uint)vehicleState.LaneSpeedRandInterval + 1u) - vehicleState.LaneSpeedRandInterval / 2f;
 						relMeanSpeedInPercent += randSpeed;
 					}
 
@@ -1357,7 +1357,7 @@ namespace TrafficManager.Manager.Impl {
 					return bestStayNext1LaneIndex;
 				}
 
-				if (bestStayTotalLaneDist != bestOptTotalLaneDist && Math.Max(bestStayTotalLaneDist, bestOptTotalLaneDist) > vehicleState.maxOptLaneChanges) {
+				if (bestStayTotalLaneDist != bestOptTotalLaneDist && Math.Max(bestStayTotalLaneDist, bestOptTotalLaneDist) > vehicleState.MaxOptLaneChanges) {
 					/*
 					 * best route contains more lane changes than allowed: choose lane with the least number of future lane changes
 					 */
@@ -1394,8 +1394,8 @@ namespace TrafficManager.Manager.Impl {
 						Log._Debug($"VehicleBehaviorManager.FindBestLane({vehicleId}): a lane change for speed improvement is possible. optImprovementInKmH={optImprovementInKmH} km/h speedDiff={speedDiff} (bestOptMeanSpeed={bestOptMeanSpeed}, vehicleCurVelocity={vehicleCurSpeed}, foundSafeLaneChange={foundSafeLaneChange})");
 					}
 #endif
-					if (optImprovementInKmH >= vehicleState.minSafeSpeedImprovement &&
-						(foundSafeLaneChange || (speedDiff <= vehicleState.maxUnsafeSpeedDiff))
+					if (optImprovementInKmH >= vehicleState.MinSafeSpeedImprovement &&
+						(foundSafeLaneChange || (speedDiff <= vehicleState.MaxUnsafeSpeedDiff))
 						) {
 						// speed improvement is significant
 #if DEBUG
@@ -1421,7 +1421,7 @@ namespace TrafficManager.Manager.Impl {
 						Log._Debug($"VehicleBehaviorManager.FindBestLane({vehicleId}): found a lane change that optimizes overall traffic. optimization={optimization}%");
 					}
 #endif
-					if (optimization >= vehicleState.minSafeTrafficImprovement) {
+					if (optimization >= vehicleState.MinSafeTrafficImprovement) {
 						// traffic optimization is significant
 #if DEBUG
 						if (debug) {
@@ -1471,7 +1471,7 @@ namespace TrafficManager.Manager.Impl {
 				return false;
 			}
 
-			if (vehicleState.heavyVehicle) {
+			if (vehicleState.IsHeavyVehicle) {
 #if DEBUG
 				if (debug) {
 					Log._Debug($"VehicleBehaviorManager.MayFindBestLane({vehicleId}): Skipping lane checking. Vehicle is heavy.");
@@ -1480,10 +1480,10 @@ namespace TrafficManager.Manager.Impl {
 				return false;
 			}
 
-			if ((vehicleState.vehicleType & (ExtVehicleType.RoadVehicle & ~ExtVehicleType.Bus)) == ExtVehicleType.None) {
+			if ((vehicleState.VehicleType & (ExtVehicleType.RoadVehicle & ~ExtVehicleType.Bus)) == ExtVehicleType.None) {
 #if DEBUG
 				if (debug) {
-					Log._Debug($"VehicleBehaviorManager.MayFindBestLane({vehicleId}): Skipping lane checking. vehicleType={vehicleState.vehicleType}");
+					Log._Debug($"VehicleBehaviorManager.MayFindBestLane({vehicleId}): Skipping lane checking. vehicleType={vehicleState.VehicleType}");
 				}
 #endif
 				return false;

--- a/TLM/TLM/Manager/Impl/VehicleStateManager.cs
+++ b/TLM/TLM/Manager/Impl/VehicleStateManager.cs
@@ -29,7 +29,7 @@ namespace TrafficManager.Manager.Impl {
 			base.InternalPrintDebugInfo();
 			Log._Debug($"Vehicle states:");
 			for (int i = 0; i < VehicleStates.Length; ++i) {
-				if ((VehicleStates[i].flags & VehicleState.Flags.Spawned) == VehicleState.Flags.None) {
+				if ((VehicleStates[i].VehicleFlags & VehicleState.Flags.Spawned) == VehicleState.Flags.None) {
 					continue;
 				}
 				Log._Debug($"Vehicle {i}: {VehicleStates[i]}");
@@ -48,7 +48,7 @@ namespace TrafficManager.Manager.Impl {
 		}
 
 		protected void LogTraffic(ushort vehicleId, ref VehicleState state) {
-			if (state.currentSegmentId == 0) {
+			if (state.CurrentSegmentId == 0) {
 				return;
 			}
 #if MEASUREDENSITY
@@ -58,7 +58,7 @@ namespace TrafficManager.Manager.Impl {
 			}
 #endif
 
-			TrafficMeasurementManager.Instance.AddTraffic(state.currentSegmentId, state.currentLaneIndex
+			TrafficMeasurementManager.Instance.AddTraffic(state.CurrentSegmentId, state.CurrentLaneIndex
 #if MEASUREDENSITY
 				, length
 #endif
@@ -146,11 +146,11 @@ namespace TrafficManager.Manager.Impl {
 		}
 
 		public void SetNextVehicleIdOnSegment(ushort vehicleId, ushort nextVehicleId) {
-			VehicleStates[vehicleId].nextVehicleIdOnSegment = nextVehicleId;
+			VehicleStates[vehicleId].NextVehicleIdOnSegment = nextVehicleId;
 		}
 
 		public void SetPreviousVehicleIdOnSegment(ushort vehicleId, ushort previousVehicleId) {
-			VehicleStates[vehicleId].previousVehicleIdOnSegment = previousVehicleId;
+			VehicleStates[vehicleId].PreviousVehicleIdOnSegment = previousVehicleId;
 		}
 
 		internal void UpdateVehiclePosition(ushort vehicleId, ref Vehicle vehicleData) {
@@ -164,11 +164,11 @@ namespace TrafficManager.Manager.Impl {
 		protected void UpdateVehiclePosition(ref Vehicle vehicleData, ref VehicleState state) {
 #if DEBUG
 			if (GlobalConfig.Instance.Debug.Switches[9])
-				Log._Debug($"VehicleStateManager.UpdateVehiclePosition({state.vehicleId}) called");
+				Log._Debug($"VehicleStateManager.UpdateVehiclePosition({state.VehicleId}) called");
 #endif
 
 			if (vehicleData.m_path == 0 || (vehicleData.m_flags & Vehicle.Flags.WaitingPath) != 0 ||
-				(state.lastPathId == vehicleData.m_path && state.lastPathPositionIndex == vehicleData.m_pathPositionIndex)
+				(state.LastPathId == vehicleData.m_path && state.LastPathPositionIndex == vehicleData.m_pathPositionIndex)
 			) {
 				return;
 			}

--- a/TLM/TLM/Traffic/Data/VehicleState.cs
+++ b/TLM/TLM/Traffic/Data/VehicleState.cs
@@ -90,7 +90,7 @@ namespace TrafficManager.Traffic.Data {
                 }
 
                 public VehicleJunctionTransitState JunctionTransitState {
-                        get => junctionTransitState_;
+                        get { return junctionTransitState_; }
                         set {
                                 if (value != junctionTransitState_) {
                                         LastTransitStateUpdate = Now();
@@ -696,29 +696,22 @@ namespace TrafficManager.Traffic.Data {
                                 case VehicleInfo.VehicleType.Bicycle:
                                         return ExtVehicleType.Bicycle;
                                 case VehicleInfo.VehicleType.Car:
-                                        switch (ai) {
-                                                case PassengerCarAI _:
-                                                        return ExtVehicleType.PassengerCar;
-                                                case AmbulanceAI _:
-                                                case FireTruckAI _:
-                                                case PoliceCarAI _:
-                                                case HearseAI _:
-                                                case GarbageTruckAI _:
-                                                case MaintenanceTruckAI _:
-                                                case SnowTruckAI _:
-                                                case WaterTruckAI _:
-                                                case DisasterResponseVehicleAI _:
-                                                case ParkMaintenanceVehicleAI _:
-                                                case PostVanAI _:
-                                                        return ExtVehicleType.Service;
-                                                case CarTrailerAI _:
-                                                        return ExtVehicleType.None;
-                                                case BusAI _:
-                                                        return ExtVehicleType.Bus;
-                                                case TaxiAI _:
-                                                        return ExtVehicleType.Taxi;
-                                                case CargoTruckAI _:
-                                                        return ExtVehicleType.CargoTruck;
+                                        if (ai is PassengerCarAI) {
+                                                return ExtVehicleType.PassengerCar;
+                                        } else if (ai is AmbulanceAI || ai is FireTruckAI || ai is PoliceCarAI ||
+                                                   ai is HearseAI || ai is GarbageTruckAI ||
+                                                   ai is MaintenanceTruckAI || ai is SnowTruckAI ||
+                                                   ai is WaterTruckAI || ai is DisasterResponseVehicleAI ||
+                                                   ai is ParkMaintenanceVehicleAI || ai is PostVanAI) {
+                                                return ExtVehicleType.Service;
+                                        } else if (ai is CarTrailerAI) {
+                                                return ExtVehicleType.None;
+                                        } else if (ai is BusAI) {
+                                                return ExtVehicleType.Bus;
+                                        } else if (ai is TaxiAI) {
+                                                return ExtVehicleType.Taxi;
+                                        } else if (ai is CargoTruckAI) {
+                                                return ExtVehicleType.CargoTruck;
                                         }
 
                                         break;
@@ -739,11 +732,10 @@ namespace TrafficManager.Traffic.Data {
                                         //if (ai is CargoShipAI)
                                 //break;
                                 case VehicleInfo.VehicleType.Plane:
-                                        switch (ai) {
-                                                case PassengerPlaneAI _:
-                                                        return ExtVehicleType.PassengerPlane;
-                                                case CargoPlaneAI _:
-                                                        return ExtVehicleType.CargoPlane;
+                                        if (ai is PassengerPlaneAI) {
+                                                return ExtVehicleType.PassengerPlane;
+                                        } else if (ai is CargoPlaneAI) {
+                                                return ExtVehicleType.CargoPlane;
                                         }
 
                                         break;

--- a/TLM/TLM/Traffic/Impl/SegmentEnd.cs
+++ b/TLM/TLM/Traffic/Impl/SegmentEnd.cs
@@ -20,11 +20,11 @@ using TrafficManager.Geometry.Impl;
 using TrafficManager.Manager.Impl;
 using TrafficManager.Traffic.Data;
 
-/// <summary>
-/// A segment end describes a directional traffic segment connected to a controlled node
-/// (having custom traffic lights or priority signs).
-/// </summary>
 namespace TrafficManager.Traffic.Impl {
+        /// <summary>
+        /// A segment end describes a directional traffic segment connected to a controlled node
+        /// (having custom traffic lights or priority signs).
+        /// </summary>
 	public class SegmentEnd : SegmentEndId, ISegmentEnd {
 		// TODO convert to struct
 
@@ -116,7 +116,7 @@ namespace TrafficManager.Traffic.Impl {
 					break;
 				}
 
-				vehicleId = vehStateManager.VehicleStates[vehicleId].nextVehicleIdOnSegment;
+				vehicleId = vehStateManager.VehicleStates[vehicleId].NextVehicleIdOnSegment;
 			}
 
 #if DEBUGMETRIC
@@ -129,10 +129,10 @@ namespace TrafficManager.Traffic.Impl {
 		protected void MeasureOutgoingVehicle(bool debug, IDictionary<ushort, uint>[] ret, bool includeStopped, uint avgSegmentLength, ushort vehicleId, ref VehicleState state, ref int numProcessed) {
 #if DEBUGMETRIC
 			if (debug)
-				Log._Debug($" MeasureOutgoingVehicle: (Segment {SegmentId}, Node {NodeId} (start={StartNode})) Checking vehicle {vehicleId}. Coming from seg. {state.currentSegmentId}, start {state.currentStartNode}, lane {state.currentLaneIndex} going to seg. {state.nextSegmentId}, lane {state.nextLaneIndex}");
+				Log._Debug($" MeasureOutgoingVehicle: (Segment {SegmentId}, Node {NodeId} (start={StartNode})) Checking vehicle {vehicleId}. Coming from seg. {state.CurrentSegmentId}, start {state.IsCurrentStartNode}, lane {state.CurrentLaneIndex} going to seg. {state.NextSegmentId}, lane {state.NextLaneIndex}");
 #endif
 
-			if ((state.flags & VehicleState.Flags.Spawned) == VehicleState.Flags.None) {
+			if ((state.VehicleFlags & VehicleState.Flags.Spawned) == VehicleState.Flags.None) {
 #if DEBUGMETRIC
 				if (debug)
 					Log._Debug($" MeasureOutgoingVehicle: Vehicle {vehicleId} is unspawned. Ignoring.");
@@ -141,7 +141,7 @@ namespace TrafficManager.Traffic.Impl {
 			}
 
 #if DEBUGMETRIC
-			if (state.currentSegmentId != SegmentId || state.currentStartNode != StartNode) {
+			if (state.CurrentSegmentId != SegmentId || state.IsCurrentStartNode != StartNode) {
 				if (debug)
 					Log._Debug($" MeasureOutgoingVehicle: (Segment {SegmentId}, Node {NodeId} (start={StartNode})) Vehicle {vehicleId} error: Segment end mismatch! {state.ToString()}");
 				//RequestCleanup();
@@ -149,7 +149,7 @@ namespace TrafficManager.Traffic.Impl {
 			}
 #endif
 
-			if (state.nextSegmentId == 0) {
+			if (state.NextSegmentId == 0) {
 #if DEBUGMETRIC
 				if (debug)
 					Log._Debug($" MeasureOutgoingVehicle: (Segment {SegmentId}, Node {NodeId} (start={StartNode})) Vehicle {vehicleId}: Ignoring vehicle");
@@ -157,10 +157,10 @@ namespace TrafficManager.Traffic.Impl {
 				return;
 			}
 
-			if (state.currentLaneIndex >= ret.Length || !ret[state.currentLaneIndex].ContainsKey(state.nextSegmentId)) {
+			if (state.CurrentLaneIndex >= ret.Length || !ret[state.CurrentLaneIndex].ContainsKey(state.NextSegmentId)) {
 #if DEBUGMETRIC
 				if (debug)
-					Log._Debug($" MeasureOutgoingVehicle: (Segment {SegmentId}, Node {NodeId} (start={StartNode})) Vehicle {vehicleId} is on lane {state.currentLaneIndex} and wants to go to segment {state.nextSegmentId} but one or both are invalid: {ret.CollectionToString()}");
+					Log._Debug($" MeasureOutgoingVehicle: (Segment {SegmentId}, Node {NodeId} (start={StartNode})) Vehicle {vehicleId} is on lane {state.CurrentLaneIndex} and wants to go to segment {state.NextSegmentId} but one or both are invalid: {ret.CollectionToString()}");
 #endif
 				return;
 			}
@@ -177,20 +177,20 @@ namespace TrafficManager.Traffic.Impl {
 			
 			uint normLength = 10u;
 			if (avgSegmentLength > 0) {
-				normLength = Math.Min(100u, (uint)(Math.Max(1u, state.totalLength) * 100u) / avgSegmentLength) + 1; // TODO +1 because the vehicle length calculation for trains/monorail in the method VehicleState.OnVehicleSpawned returns 0 (or a very small number maybe?)
+				normLength = Math.Min(100u, (uint)(Math.Max(1u, state.TotalLength) * 100u) / avgSegmentLength) + 1; // TODO +1 because the vehicle length calculation for trains/monorail in the method VehicleState.OnVehicleSpawned returns 0 (or a very small number maybe?)
 			}
 
 #if DEBUGMETRIC
 			if (debug)
-				Log._Debug($"  MeasureOutgoingVehicle: (Segment {SegmentId}, Node {NodeId}) NormLength of vehicle {vehicleId}: {state.totalLength} -> {normLength} (avgSegmentLength={avgSegmentLength})");
+				Log._Debug($"  MeasureOutgoingVehicle: (Segment {SegmentId}, Node {NodeId}) NormLength of vehicle {vehicleId}: {state.TotalLength} -> {normLength} (avgSegmentLength={avgSegmentLength})");
 #endif
 
-			ret[state.currentLaneIndex][state.nextSegmentId] += normLength;
+			ret[state.CurrentLaneIndex][state.NextSegmentId] += normLength;
 			++numProcessed;
 
 #if DEBUGMETRIC
 			if (debug)
-				Log._Debug($"  MeasureOutgoingVehicle: (Segment {SegmentId}, Node {NodeId}) Vehicle {vehicleId}: ***ADDED*** ({state.currentSegmentId}@{state.currentLaneIndex} -> {state.nextSegmentId}@{state.nextLaneIndex})!");
+				Log._Debug($"  MeasureOutgoingVehicle: (Segment {SegmentId}, Node {NodeId}) Vehicle {vehicleId}: ***ADDED*** ({state.CurrentSegmentId}@{state.CurrentLaneIndex} -> {state.NextSegmentId}@{state.NextLaneIndex})!");
 #endif
 
 			return;
@@ -203,7 +203,7 @@ namespace TrafficManager.Traffic.Impl {
 			int ret = 0;
 			while (vehicleId != 0) {
 				++ret;
-				vehicleId = vehStateManager.VehicleStates[vehicleId].nextVehicleIdOnSegment;
+				vehicleId = vehStateManager.VehicleStates[vehicleId].NextVehicleIdOnSegment;
 			}
 			return ret;
 		}

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -946,8 +946,8 @@ namespace TrafficManager.UI {
 
 				VehicleState vState = vehStateManager.VehicleStates[(ushort)i];
 				ExtCitizenInstance driverInst = ExtCitizenInstanceManager.Instance.ExtInstances[CustomPassengerCarAI.GetDriverInstanceId((ushort)i, ref Singleton<VehicleManager>.instance.m_vehicles.m_buffer[i])];
-				bool startNode = vState.currentStartNode;
-				ushort segmentId = vState.currentSegmentId;
+				bool startNode = vState.IsCurrentStartNode;
+				ushort segmentId = vState.CurrentSegmentId;
 				ushort vehSpeed = SpeedLimitManager.Instance.VehicleToCustomSpeed(vehicle.GetLastFrameVelocity().magnitude);
 
 #if DEBUG
@@ -956,8 +956,8 @@ namespace TrafficManager.UI {
 				}
 #endif
 
-				String labelStr = "V #" + i + " is a " + (vState.recklessDriver ? "reckless " : "") + vState.flags + " " + vState.vehicleType + " @ ~" + vehSpeed + " km/h [^2=" + vState.SqrVelocity + "] (len: " + vState.totalLength + ", " + vState.JunctionTransitState + " @ " + vState.currentSegmentId + " (" + vState.currentStartNode + "), l. " + vState.currentLaneIndex + " -> " + vState.nextSegmentId + ", l. " + vState.nextLaneIndex + "), w: " + vState.waitTime + "\n" +
-					"di: " + driverInst.instanceId + " dc: " + driverInst.GetCitizenId() + " m: " + driverInst.pathMode.ToString() + " f: " + driverInst.failedParkingAttempts + " l: " + driverInst.parkingSpaceLocation + " lid: " + driverInst.parkingSpaceLocationId + " ltsu: " + vState.lastTransitStateUpdate + " lpu: " + vState.lastPositionUpdate + " als: " + vState.lastAltLaneSelSegmentId + " srnd: " + Constants.ManagerFactory.VehicleBehaviorManager.GetStaticVehicleRand((ushort)i) + " trnd: " + Constants.ManagerFactory.VehicleBehaviorManager.GetTimedVehicleRand((ushort)i);
+				String labelStr = "V #" + i + " is a " + (vState.IsRecklessDriver ? "reckless " : "") + vState.VehicleFlags + " " + vState.VehicleType + " @ ~" + vehSpeed + " km/h [^2=" + vState.SqrVelocity + "] (len: " + vState.TotalLength + ", " + vState.JunctionTransitState + " @ " + vState.CurrentSegmentId + " (" + vState.IsCurrentStartNode + "), l. " + vState.CurrentLaneIndex + " -> " + vState.NextSegmentId + ", l. " + vState.NextLaneIndex + "), w: " + vState.WaitTime + "\n" +
+					"di: " + driverInst.instanceId + " dc: " + driverInst.GetCitizenId() + " m: " + driverInst.pathMode.ToString() + " f: " + driverInst.failedParkingAttempts + " l: " + driverInst.parkingSpaceLocation + " lid: " + driverInst.parkingSpaceLocationId + " ltsu: " + vState.LastTransitStateUpdate + " lpu: " + vState.LastPositionUpdate + " als: " + vState.LastAltLaneSelSegmentId + " srnd: " + Constants.ManagerFactory.VehicleBehaviorManager.GetStaticVehicleRand((ushort)i) + " trnd: " + Constants.ManagerFactory.VehicleBehaviorManager.GetTimedVehicleRand((ushort)i);
 
 				Vector2 dim = _counterStyle.CalcSize(new GUIContent(labelStr));
 				Rect labelRect = new Rect(screenPos.x - dim.x / 2f, screenPos.y - dim.y - 50f, dim.x, dim.y);


### PR DESCRIPTION
- Untabified
- Fixed StyleCop warnings and Resharper suggestions in VehicleState
  - Renamed fields according to their private/public setting
  - Renamed boolean fields to `Is<Something>`
  - Method ordering changed as StyleCop suggests
  - `if () action` operators changed to `if () { action }` even for one-liners