### PR TITLE
Add Function to Disable & Remove Traffic Lights

### DIFF
--- a/TLM/TLM/Custom/AI/CustomRoadAI.cs
+++ b/TLM/TLM/Custom/AI/CustomRoadAI.cs
@@ -719,9 +719,10 @@ namespace TrafficManager.Custom.AI {
         return;
       }
 
-			// test for not Flags.Junction is unnecessary because tested in IsTrafficLightToggleable
-			// but it's a simple and fast exit, while IsTrafficLightToggleable is quite complex
-      if(!data.m_flags.IsFlagSet(NetNode.Flags.Junction) || !TrafficLightManager.Instance.IsTrafficLightToggleable(nodeId, false, ref data, out var _))
+      // test for not Flags.Junction is unnecessary because tested in IsTrafficLightToggleable
+      // but it's a simple and fast exit, while IsTrafficLightToggleable is quite complex
+      UnableReason unableReason;
+      if(!data.m_flags.IsFlagSet(NetNode.Flags.Junction) || !TrafficLightManager.Instance.IsTrafficLightToggleable(nodeId, false, ref data, out unableReason))
       {
         return;
       }

--- a/TLM/TLM/LoadingExtension.cs
+++ b/TLM/TLM/LoadingExtension.cs
@@ -1424,6 +1424,15 @@ namespace TrafficManager {
 					Log.Error("Could not redirect RoadBaseAI::SimulationStep.");
 				}
 
+				Log.Info("Redirecting RoadBaseAI.UpdateNode for nodes");
+				try {
+					Detours.Add(new Detour(typeof(RoadBaseAI).GetMethod(nameof(RoadBaseAI.UpdateNode), new[] { typeof(ushort), typeof(NetNode).MakeByRefType() }),
+						typeof(CustomRoadAI).GetMethod(nameof(CustomRoadAI.CustomUpdateNode))));
+				} catch (Exception) {
+					Log.Error("Could not redirect RoadBaseAI::UpdateNode.");
+					detourFailed = true;
+				}
+
 				Log.Info("Redirection BuildingAI::GetColor calls");
 				try {
 					Detours.Add(new Detour(typeof(BuildingAI).GetMethod("GetColor",

--- a/TLM/TLM/Manager/Impl/OptionsManager.cs
+++ b/TLM/TLM/Manager/Impl/OptionsManager.cs
@@ -189,6 +189,10 @@ namespace TrafficManager.Manager.Impl {
 				Options.setAllowFarTurnOnRed(data[40] == (byte)1);
 			}
 
+			if (data.Length >= 42) {
+				Options.setCreateAllJunctionsWithoutTrafficLights(data[41] == (byte)1);
+			}
+
 			return true;
 		}
 
@@ -234,7 +238,8 @@ namespace TrafficManager.Manager.Impl {
 						(byte)(Options.realisticPublicTransport ? 1 : 0),
 						(byte)(Options.turnOnRedEnabled ? 1 : 0),
 						(byte)(Options.allowNearTurnOnRed ? 1 : 0),
-						(byte)(Options.allowFarTurnOnRed ? 1 : 0)
+						(byte)(Options.allowFarTurnOnRed ? 1 : 0),
+						(byte)(Options.createAllJunctionsWithoutTrafficLights ? 1 : 0),
 				};
 		}
 	}

--- a/TLM/TLM/Manager/Impl/TrafficLightManager.cs
+++ b/TLM/TLM/Manager/Impl/TrafficLightManager.cs
@@ -170,6 +170,15 @@ namespace TrafficManager.Manager.Impl {
 			return LogicUtil.CheckFlags((uint)node.m_flags, (uint)(NetNode.Flags.Created | NetNode.Flags.Deleted | NetNode.Flags.TrafficLights), (uint)(NetNode.Flags.Created | NetNode.Flags.TrafficLights));
 		}
 
+		public void RemoveAllExistingTrafficLights()
+    {
+      var nodes = NetManager.instance.m_nodes;
+      for(ushort i = 0; i < nodes.m_size; i++)
+      {
+        RemoveTrafficLight(i, ref nodes.m_buffer[i]);
+      }
+    }
+
 		[Obsolete]
 		public bool LoadData(string data) {
 			bool success = true;

--- a/TLM/TLM/Resources/lang.txt
+++ b/TLM/TLM/Resources/lang.txt
@@ -222,6 +222,8 @@ Junctions Junctions
 Create_all_junctions_without_traffic_lights Create without traffic lights
 Remove_all_existing_traffic_lights Remove all existing traffic lights
 Remove_all_existing_traffic_lights_tooltip excluding timed traffic lights
+Remove_all_existing_traffic_lights_dialog_title Remove all traffic lights
+Remove_all_existing_traffic_lights_dialog_message Are you sure you want to remove all existing traffic lights?
 Compact_main_menu Compact main menu
 Window_transparency Window transparency
 Overlay_transparency Overlay transparency

--- a/TLM/TLM/Resources/lang.txt
+++ b/TLM/TLM/Resources/lang.txt
@@ -218,6 +218,9 @@ TMPE_TUTORIAL_HEAD_TimedTrafficLightsTool_RemoveJunction Remove a junction from 
 TMPE_TUTORIAL_BODY_TimedTrafficLightsTool_RemoveJunction Click on one of the junctions that are controlled by this timed program. The selected traffic light will be removed such that the timed programm will no longer manage it.\n\nClick anywhere with your secondary mouse button to cancel the operation.
 Public_transport Public transport
 Prevent_excessive_transfers_at_public_transport_stations Prevent unnecessary transfers at public transport stations
+Junctions Junctions
+Remove_all_existing_traffic_lights Remove all existing traffic lights
+Remove_all_existing_traffic_lights_tooltip excluding timed traffic lights
 Compact_main_menu Compact main menu
 Window_transparency Window transparency
 Overlay_transparency Overlay transparency

--- a/TLM/TLM/Resources/lang.txt
+++ b/TLM/TLM/Resources/lang.txt
@@ -219,6 +219,7 @@ TMPE_TUTORIAL_BODY_TimedTrafficLightsTool_RemoveJunction Click on one of the jun
 Public_transport Public transport
 Prevent_excessive_transfers_at_public_transport_stations Prevent unnecessary transfers at public transport stations
 Junctions Junctions
+Create_all_junctions_without_traffic_lights Create without traffic lights
 Remove_all_existing_traffic_lights Remove all existing traffic lights
 Remove_all_existing_traffic_lights_tooltip excluding timed traffic lights
 Compact_main_menu Compact main menu

--- a/TLM/TLM/State/Options.cs
+++ b/TLM/TLM/State/Options.cs
@@ -261,6 +261,8 @@ namespace TrafficManager.State {
 #if DEBUG
             resetSpeedLimitsBtn = maintenanceGroup.AddButton(Translation.GetString("Reset_custom_speed_limits"), onClickResetSpeedLimits) as UIButton;
 #endif
+			removeAllExistingTrafficLightsBtn = (UIButton)maintenanceGroup.AddButton(Translation.GetString("Remove_all_existing_traffic_lights"), onClickRemoveAllExistingTrafficLights);
+			removeAllExistingTrafficLightsBtn.tooltip = Translation.GetString("Remove_all_existing_traffic_lights_tooltip");
             reloadGlobalConfBtn = maintenanceGroup.AddButton(Translation.GetString("Reload_global_configuration"), onClickReloadGlobalConf) as UIButton;
             resetGlobalConfBtn = maintenanceGroup.AddButton(Translation.GetString("Reset_global_configuration"), onClickResetGlobalConf) as UIButton;
 
@@ -392,8 +394,6 @@ namespace TrafficManager.State {
 
 			var jGroup = panelHelper.AddGroup(Translation.GetString(Translation.GetString("Junctions")));
 			createAllJunctionsWithoutTrafficLightsToggle = (UICheckBox)jGroup.AddCheckbox(Translation.GetString("Create_all_junctions_without_traffic_lights"), createAllJunctionsWithoutTrafficLights, onCreateAllJunctionsWithoutTrafficLightsChanged);
-			removeAllExistingTrafficLightsBtn = (UIButton)jGroup.AddButton(Translation.GetString("Remove_all_existing_traffic_lights"), onClickRemoveAllExistingTrafficLights);
-			removeAllExistingTrafficLightsBtn.tooltip = Translation.GetString("Remove_all_existing_traffic_lights_tooltip");
         }
 
         private static void MakeSettings_General(UITabstrip tabStrip, int tabIndex) {

--- a/TLM/TLM/State/Options.cs
+++ b/TLM/TLM/State/Options.cs
@@ -61,6 +61,7 @@ namespace TrafficManager.State {
         private static UICheckBox prohibitPocketCarsToggle = null;
         private static UICheckBox advancedAIToggle = null;
         private static UICheckBox realisticPublicTransportToggle = null;
+		private static UIButton removeAllExistingTrafficLightsBtn = null;
         private static UISlider altLaneSelectionRatioSlider = null;
         private static UICheckBox highwayRulesToggle = null;
         private static UICheckBox preferOuterLaneToggle = null;
@@ -386,6 +387,10 @@ namespace TrafficManager.State {
 
             var ptGroup = panelHelper.AddGroup(Translation.GetString("Public_transport"));
             realisticPublicTransportToggle = ptGroup.AddCheckbox(Translation.GetString("Prevent_excessive_transfers_at_public_transport_stations"), realisticPublicTransport, onRealisticPublicTransportChanged) as UICheckBox;
+
+			var jGroup = panelHelper.AddGroup(Translation.GetString(Translation.GetString("Junctions")));
+			removeAllExistingTrafficLightsBtn = (UIButton)jGroup.AddButton(Translation.GetString("Remove_all_existing_traffic_lights"), onClickRemoveAllExistingTrafficLights);
+			removeAllExistingTrafficLightsBtn.tooltip = Translation.GetString("Remove_all_existing_traffic_lights_tooltip");
         }
 
         private static void MakeSettings_General(UITabstrip tabStrip, int tabIndex) {
@@ -1013,6 +1018,16 @@ namespace TrafficManager.State {
             Log._Debug($"realisticPublicTransport changed to {newValue}");
             realisticPublicTransport = newValue;
         }
+
+		private static void onClickRemoveAllExistingTrafficLights() {
+			if (!checkGameLoaded())
+				return;
+
+			Log._Debug("Remove all existing Traffic Lights");
+			Constants.ServiceFactory.SimulationService.AddAction(() => {
+                TrafficLightManager.Instance.RemoveAllExistingTrafficLights();
+            });
+		}
 
         private static void onIndividualDrivingStyleChanged(bool value) {
             if (!checkGameLoaded())

--- a/TLM/TLM/State/Options.cs
+++ b/TLM/TLM/State/Options.cs
@@ -61,6 +61,7 @@ namespace TrafficManager.State {
         private static UICheckBox prohibitPocketCarsToggle = null;
         private static UICheckBox advancedAIToggle = null;
         private static UICheckBox realisticPublicTransportToggle = null;
+		private static UICheckBox createAllJunctionsWithoutTrafficLightsToggle = null;
 		private static UIButton removeAllExistingTrafficLightsBtn = null;
         private static UISlider altLaneSelectionRatioSlider = null;
         private static UICheckBox highwayRulesToggle = null;
@@ -136,6 +137,7 @@ namespace TrafficManager.State {
         public static bool banRegularTrafficOnBusLanes = false;
         public static bool advancedAI = false;
         public static bool realisticPublicTransport = false;
+		public static bool createAllJunctionsWithoutTrafficLights = false;
         public static byte altLaneSelectionRatio = 0;
         public static bool highwayRules = false;
 #if DEBUG
@@ -389,6 +391,7 @@ namespace TrafficManager.State {
             realisticPublicTransportToggle = ptGroup.AddCheckbox(Translation.GetString("Prevent_excessive_transfers_at_public_transport_stations"), realisticPublicTransport, onRealisticPublicTransportChanged) as UICheckBox;
 
 			var jGroup = panelHelper.AddGroup(Translation.GetString(Translation.GetString("Junctions")));
+			createAllJunctionsWithoutTrafficLightsToggle = (UICheckBox)jGroup.AddCheckbox(Translation.GetString("Create_all_junctions_without_traffic_lights"), createAllJunctionsWithoutTrafficLights, onCreateAllJunctionsWithoutTrafficLightsChanged);
 			removeAllExistingTrafficLightsBtn = (UIButton)jGroup.AddButton(Translation.GetString("Remove_all_existing_traffic_lights"), onClickRemoveAllExistingTrafficLights);
 			removeAllExistingTrafficLightsBtn.tooltip = Translation.GetString("Remove_all_existing_traffic_lights_tooltip");
         }
@@ -1018,6 +1021,14 @@ namespace TrafficManager.State {
             Log._Debug($"realisticPublicTransport changed to {newValue}");
             realisticPublicTransport = newValue;
         }
+
+		private static void onCreateAllJunctionsWithoutTrafficLightsChanged(bool newValue) {
+      if(!checkGameLoaded())
+        return;
+
+      Log._Debug($"{nameof(createAllJunctionsWithoutTrafficLights)} changed to {newValue}");
+      createAllJunctionsWithoutTrafficLights = newValue;
+    }
 
 		private static void onClickRemoveAllExistingTrafficLights() {
 			if (!checkGameLoaded())

--- a/TLM/TLM/State/Options.cs
+++ b/TLM/TLM/State/Options.cs
@@ -1031,13 +1031,23 @@ namespace TrafficManager.State {
     }
 
 		private static void onClickRemoveAllExistingTrafficLights() {
-			if (!checkGameLoaded())
-				return;
+      if (!checkGameLoaded())
+        return;
 
-			Log._Debug("Remove all existing Traffic Lights");
-			Constants.ServiceFactory.SimulationService.AddAction(() => {
-                TrafficLightManager.Instance.RemoveAllExistingTrafficLights();
-            });
+      // invasive action -> ask first
+      ConfirmPanel.ShowModal(Translation.GetString("Remove_all_existing_traffic_lights_dialog_title"), Translation.GetString("Remove_all_existing_traffic_lights_dialog_message"), (_, result) =>
+      {
+        if(result != 1)
+        {
+          return;
+        }
+
+        Log._Debug("Remove all existing Traffic Lights");
+        Constants.ServiceFactory.SimulationService.AddAction(() =>
+        {
+          TrafficLightManager.Instance.RemoveAllExistingTrafficLights();
+        });
+      });
 		}
 
         private static void onIndividualDrivingStyleChanged(bool value) {

--- a/TLM/TLM/State/Options.cs
+++ b/TLM/TLM/State/Options.cs
@@ -1312,6 +1312,13 @@ namespace TrafficManager.State {
                 realisticPublicTransportToggle.isChecked = newValue;
         }
 
+		public static void setCreateAllJunctionsWithoutTrafficLights(bool newValue) {
+			bool valueChanged = newValue != createAllJunctionsWithoutTrafficLights;
+			createAllJunctionsWithoutTrafficLights = newValue;
+			if (createAllJunctionsWithoutTrafficLightsToggle != null)
+				createAllJunctionsWithoutTrafficLightsToggle.isChecked = newValue;
+		}
+
         public static void setIndividualDrivingStyle(bool newValue) {
             individualDrivingStyle = newValue;
 


### PR DESCRIPTION
Button to remove / disable all traffic lights

Adds a new junctions settings group under "Gameplay" to:
* disable traffic lights at new junctions
  * touches only new junctions, not existing ones
  * still allows adding lights manually -- it only prevents lights at new junctions
* remove all traffic lights at existing junctions
  * doesn't remove timed traffic lights
  * because quite drastic and undoable: confirmation dialog before execution

Fixes #320