### PR TITLE
Undo the dreadful tab indent in .editorconfig

### DIFF
--- a/TLM/.editorconfig
+++ b/TLM/.editorconfig
@@ -1,8 +1,8 @@
 ﻿root = true
 
 [*.{cs,vb}]
-indent_style = tab
-indent_size = 8
+indent_style = space
+indent_size = 4
 trim_trailing_whitespace = true
 
 [*.cs]


### PR DESCRIPTION
A recent PR introduced an .editorconfig which defined `indent_style = tab` and `indent_size = 8`.

Big nope to both.

Changed to spaces, with indent of 4.