### PR TITLE
Exclude self from offline TMPE mod check

### DIFF
--- a/TLM/TLM/TrafficManagerMod.cs
+++ b/TLM/TLM/TrafficManagerMod.cs
@@ -17,8 +17,6 @@ namespace TrafficManager {
         public static readonly uint GameVersionC = 0u;
         public static readonly uint GameVersionBuild = 5u;
 
-        public static int Build => Assembly.GetExecutingAssembly().GetName().Version.Build;
-
         // Note: `Version` is also used in UI/MainMenu/VersionLabel.cs
         public static readonly string Version = "10.20";
 
@@ -57,7 +55,7 @@ namespace TrafficManager {
 		private static void CheckForIncompatibleMods() {
             if (GlobalConfig.Instance.Main.ScanForKnownIncompatibleModsAtStartup) {
                 ModsCompatibilityChecker mcc = new ModsCompatibilityChecker();
-                mcc.PerformModCheck(Build);
+                mcc.PerformModCheck();
             }
 		}
 	}

--- a/TLM/TLM/TrafficManagerMod.cs
+++ b/TLM/TLM/TrafficManagerMod.cs
@@ -1,12 +1,9 @@
 using CSUtil.Commons;
 using ICities;
 using System.Reflection;
-using System.Runtime.CompilerServices;
-using ColossalFramework;
 using ColossalFramework.UI;
 using TrafficManager.State;
 using TrafficManager.Util;
-using UnityEngine;
 
 namespace TrafficManager {
 	public class TrafficManagerMod : IUserMod {
@@ -34,6 +31,7 @@ namespace TrafficManager {
 
         public void OnEnabled() {
 			Log.Info($"TM:PE enabled. Version {Version}, Build {Assembly.GetExecutingAssembly().GetName().Version} {Branch} for game version {GameVersionA}.{GameVersionB}.{GameVersionC}-f{GameVersionBuild}");
+            Log.Info($"Enabled TM:PE has GUID {Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId}");
 
             // check for incompatible mods
             if (UIView.GetAView() != null) { // when TM:PE is enabled in content manager

--- a/TLM/TLM/TrafficManagerMod.cs
+++ b/TLM/TLM/TrafficManagerMod.cs
@@ -17,6 +17,8 @@ namespace TrafficManager {
         public static readonly uint GameVersionC = 0u;
         public static readonly uint GameVersionBuild = 5u;
 
+        public static int Build => Assembly.GetExecutingAssembly().GetName().Version.Build;
+
         // Note: `Version` is also used in UI/MainMenu/VersionLabel.cs
         public static readonly string Version = "10.20";
 
@@ -32,7 +34,7 @@ namespace TrafficManager {
 
         public string Description => "Manage your city's traffic";
 
-		public void OnEnabled() {
+        public void OnEnabled() {
 			Log.Info($"TM:PE enabled. Version {Version}, Build {Assembly.GetExecutingAssembly().GetName().Version} {Branch} for game version {GameVersionA}.{GameVersionB}.{GameVersionC}-f{GameVersionBuild}");
 
             // check for incompatible mods
@@ -55,7 +57,7 @@ namespace TrafficManager {
 		private static void CheckForIncompatibleMods() {
             if (GlobalConfig.Instance.Main.ScanForKnownIncompatibleModsAtStartup) {
                 ModsCompatibilityChecker mcc = new ModsCompatibilityChecker();
-                mcc.PerformModCheck();
+                mcc.PerformModCheck(Build);
             }
 		}
 	}

--- a/TLM/TLM/Util/ModsCompatibilityChecker.cs
+++ b/TLM/TLM/Util/ModsCompatibilityChecker.cs
@@ -1,7 +1,4 @@
 using ColossalFramework;
-#if !DEBUG
-using ColossalFramework.PlatformServices; // used in RELEASE builds
-#endif
 using ColossalFramework.Plugins;
 using ColossalFramework.UI;
 using CSUtil.Commons;
@@ -18,7 +15,6 @@ namespace TrafficManager.Util
 {
     public class ModsCompatibilityChecker
     {
-
         public const ulong LOCAL_MOD = ulong.MaxValue;
 
         // Used for LoadIncompatibleModsList()
@@ -68,9 +64,9 @@ namespace TrafficManager.Util
         /// <exception cref="PathTooLongException">Path is too long (longer than the system-defined maximum length).</exception>
         public Dictionary<PluginInfo, string> ScanForIncompatibleMods()
         {
-            Guid selfModVerId = Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId;
+            Guid selfGuid = Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId;
 
-            Log.Info($"Scanning for incompatible mods; Self GUID = {selfModVerId}");
+            Log.Info($"Scanning for incompatible mods; My GUID = {selfGuid}");
 
             // list of installed incompatible mods
             Dictionary<PluginInfo, string> results = new Dictionary<PluginInfo, string>();
@@ -78,38 +74,36 @@ namespace TrafficManager.Util
             // only check enabled mods?
             bool filterToEnabled = State.GlobalConfig.Instance.Main.IgnoreDisabledMods;
 
-#if !DEBUG
-            bool offline = IsOffline();
-#endif
-
             // iterate plugins
             foreach (PluginInfo mod in Singleton<PluginManager>.instance.GetPluginsInfo())
             {
                 if (!mod.isBuiltin && !mod.isCameraScript && (!filterToEnabled || mod.isEnabled))
                 {
                     string modName = GetModName(mod);
+                    ulong workshopID = mod.publishedFileID.AsUInt64;
 
-                    if (incompatibleMods.ContainsKey(mod.publishedFileID.AsUInt64))
+                    if (incompatibleMods.ContainsKey(workshopID))
                     {
-                        Log.Info($"Incompatible mod: {mod.publishedFileID.AsUInt64} - {modName}");
+                        // must be online workshop mod
+                        Log.Info($"Incompatible with: {workshopID} - {modName}");
                         results.Add(mod, modName);
                     }
-#if !DEBUG
-                    // Workshop TM:PE builds treat local builds as incompatible
-                    else if (!offline && mod.publishedFileID.AsUInt64 == LOCAL_MOD && (modName.Contains("TM:PE") || modName.Contains("Traffic Manager")))
+                    else if (modName.Contains("TM:PE") || modName.Contains("Traffic Manager"))
                     {
-                        if (GetModVerId(mod) == selfModVerId)
+                        // It's a TM:PE build - either local or workshop
+                        string workshopIDstr = workshopID == LOCAL_MOD ? "LOCAL" : workshopID.ToString();
+                        Guid currentGuid = GetModGuid(mod);
+
+                        if (currentGuid == selfGuid)
                         {
-                            Log.Info($"Skipping local TM:PE with GUID '{selfModVerId}' in '{mod.modPath}'");
+                            Log.Info($"Found myself: '{modName}' (Workshop ID: {workshopIDstr}, GUID: {currentGuid}) in '{mod.modPath}'");
                         }
                         else
                         {
-                            Log.Info($"Local TM:PE detected: '{modName}' in '{mod.modPath}'");
-                            string folder = Path.GetFileName(mod.modPath);
-                            results.Add(mod, $"{modName} in /{folder}");
+                            Log.Info($"Detected conflicting '{modName}' (Workshop ID: {workshopIDstr}, GUID: {currentGuid}) in '{mod.modPath}'");
+                            results.Add(mod, $"{modName} in /{Path.GetFileName(mod.modPath)}");
                         }
                     }
-#endif
                 }
             }
 
@@ -133,51 +127,16 @@ namespace TrafficManager.Util
         }
 
         /// <summary>
-        /// Gets the build number of an offline TM:PE mod
-        /// 
-        /// It will return the <see cref="IUserMod.Build"/> if found, otherwise <c>0</c>.
+        /// Gets the <see cref="Guid"/> of a mod.
         /// </summary>
         /// 
         /// <param name="plugin">The <see cref="PluginInfo"/> associated with the mod.</param>
         /// 
-        /// <returns>The name of the specified plugin.</returns>
-        public Guid GetModVerId(PluginInfo plugin)
+        /// <returns>The <see cref="Guid"/> of the mod.</returns>
+        public Guid GetModGuid(PluginInfo plugin)
         {
             return plugin.userModInstance.GetType().Assembly.ManifestModule.ModuleVersionId;
         }
-
-        /// <summary>
-        /// Works out if the game is effectively running in offline mode, in which no workshop mod subscriptions will be active.
-        /// 
-        /// Applicalbe "offline" states include:
-        /// 
-        /// * Origin plaform service (no support for Steam workshop)
-        /// * Steam (or other platform service) not active
-        /// * --noWorkshop launch option
-        /// 
-        /// This is allows LABS and STABLE builds to be used offline without trying to delete themselves.
-        /// </summary>
-        /// 
-        /// <returns>Returns <c>true</c> if game is offline for any reason, otherwise <c>false</c>.</returns>
-#if !DEBUG
-        private bool IsOffline()
-        {
-            // TODO: Work out if TGP and QQGame platform services allow workshop
-            if (PluginManager.noWorkshop)
-            {
-                return true;
-            }
-            else if (PlatformService.platformType == PlatformType.Origin)
-            {
-                return true;
-            }
-            else if (!PlatformService.active)
-            {
-                return true;
-            }
-            return false;
-        }
-#endif
 
         /// <summary>
         /// Loads and parses the <c>incompatible_mods.txt</c> resource, adds other workshop branches of TM:PE as applicable.
@@ -199,7 +158,7 @@ namespace TrafficManager.Util
                 }
             }
 
-            Log.Info($"{INCOMPATIBLE_MODS_FILE} contains {lines.Length} entries");
+            Log.Info($"{RESOURCES_PREFIX}{INCOMPATIBLE_MODS_FILE} contains {lines.Length} entries");
 
             // parse the file
             for (int i = 0; i < lines.Length; i++)
@@ -211,16 +170,6 @@ namespace TrafficManager.Util
                     results.Add(steamId, strings[1]);
                 }
             }
-
-            // Treat other workshop-published branches of TM:PE, as applicable, as conflicts
-#if LABS
-            results.Add(583429740u, "TM:PE STABLE");
-#elif DEBUG
-            results.Add(1637663252u, "TM:PE LABS");
-            results.Add(583429740u, "TM:PE STABLE");
-#else
-            results.Add(1637663252u, "TM:PE LABS");
-#endif
 
             return results;
         }

--- a/TLM/TLM/Util/ModsCompatibilityChecker.cs
+++ b/TLM/TLM/Util/ModsCompatibilityChecker.cs
@@ -96,7 +96,7 @@ namespace TrafficManager.Util
                     }
 #if !DEBUG
                     // Workshop TM:PE builds treat local builds as incompatible
-                    else if (!offline && mod.publishedFileID.AsUInt64 == LOCAL_MOD && (modName.Contains("TM:PE") || modName.Contains("Traffic Manager")) && GetModBuild(mod) != selfModVerId)
+                    else if (!offline && mod.publishedFileID.AsUInt64 == LOCAL_MOD && (modName.Contains("TM:PE") || modName.Contains("Traffic Manager")) && GetModVerId(mod) != selfModVerId)
                     {
                         Log.Info($"Local TM:PE detected: '{modName}' in '{mod.modPath}'");
                         string folder = Path.GetFileName(mod.modPath);

--- a/TLM/TLM/Util/ModsCompatibilityChecker.cs
+++ b/TLM/TLM/Util/ModsCompatibilityChecker.cs
@@ -100,7 +100,7 @@ namespace TrafficManager.Util
                     {
                         if (GetModVerId(mod) == selfModVerId)
                         {
-                            Log.Info($"Skipping local TM:PE with same GUID as self: {selfModVerId}");
+                            Log.Info($"Skipping local TM:PE with GUID '{selfModVerId}' in '{mod.modPath}'");
                         }
                         else
                         {

--- a/TLM/TLM/Util/ModsCompatibilityChecker.cs
+++ b/TLM/TLM/Util/ModsCompatibilityChecker.cs
@@ -22,11 +22,11 @@ namespace TrafficManager.Util
         private const string INCOMPATIBLE_MODS_FILE = "incompatible_mods.txt";
 
         // parsed contents of incompatible_mods.txt
-        private readonly Dictionary<ulong, string> incompatibleMods;
+        private readonly Dictionary<ulong, string> knownIncompatibleMods;
 
         public ModsCompatibilityChecker()
         {
-            incompatibleMods = LoadListOfIncompatibleMods();
+            knownIncompatibleMods = LoadListOfIncompatibleMods();
         }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace TrafficManager.Util
             {
                 Dictionary<PluginInfo, string> detected = ScanForIncompatibleMods();
 
-                if (detected.Count > 0 && State.GlobalConfig.Instance.Main.ScanForKnownIncompatibleModsAtStartup)
+                if (detected.Count > 0)
                 {
                     IncompatibleModsPanel panel = UIView.GetAView().AddUIComponent(typeof(IncompatibleModsPanel)) as IncompatibleModsPanel;
                     panel.IncompatibleMods = detected;
@@ -82,7 +82,7 @@ namespace TrafficManager.Util
                     string modName = GetModName(mod);
                     ulong workshopID = mod.publishedFileID.AsUInt64;
 
-                    if (incompatibleMods.ContainsKey(workshopID))
+                    if (knownIncompatibleMods.ContainsKey(workshopID))
                     {
                         // must be online workshop mod
                         Log.Info($"Incompatible with: {workshopID} - {modName}");

--- a/TLM/TLM/Util/ModsCompatibilityChecker.cs
+++ b/TLM/TLM/Util/ModsCompatibilityChecker.cs
@@ -70,7 +70,7 @@ namespace TrafficManager.Util
         {
             Guid selfModVerId = Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId;
 
-            Log.Info($"Scanning for incompatible mods; GUID = {selfModVerId}");
+            Log.Info($"Scanning for incompatible mods; Self GUID = {selfModVerId}");
 
             // list of installed incompatible mods
             Dictionary<PluginInfo, string> results = new Dictionary<PluginInfo, string>();
@@ -96,11 +96,18 @@ namespace TrafficManager.Util
                     }
 #if !DEBUG
                     // Workshop TM:PE builds treat local builds as incompatible
-                    else if (!offline && mod.publishedFileID.AsUInt64 == LOCAL_MOD && (modName.Contains("TM:PE") || modName.Contains("Traffic Manager")) && GetModVerId(mod) != selfModVerId)
+                    else if (!offline && mod.publishedFileID.AsUInt64 == LOCAL_MOD && (modName.Contains("TM:PE") || modName.Contains("Traffic Manager")))
                     {
-                        Log.Info($"Local TM:PE detected: '{modName}' in '{mod.modPath}'");
-                        string folder = Path.GetFileName(mod.modPath);
-                        results.Add(mod, $"{modName} in /{folder}");
+                        if (GetModVerId(mod) == selfModVerId)
+                        {
+                            Log.Info($"Skipping local TM:PE with same GUID as self: {selfModVerId}");
+                        }
+                        else
+                        {
+                            Log.Info($"Local TM:PE detected: '{modName}' in '{mod.modPath}'");
+                            string folder = Path.GetFileName(mod.modPath);
+                            results.Add(mod, $"{modName} in /{folder}");
+                        }
                     }
 #endif
                 }


### PR DESCRIPTION
> Thanks to @kvakvs for spotting the issue  
> Thanks to @dymanoid for idea to use `ManifestModule.ModuleVersionId`

Mod performing the check gets its own `Guid` from:

```csharp
 Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId
```

When checking local mods (which only happens when a build is using `RELEASE` or `RELEASE LABS`), the Guid of the mod being inspected is determined by:

```csharp
        public Guid GetModVerId(PluginInfo plugin)
        {
            return plugin.userModInstance.GetType().Assembly.ManifestModule.ModuleVersionId;
        }
```

If the two `Guid` values match, the local (offline) build is skipped by the compatibility checker, this preventing local `RELEASE` or `RELEASE LABS` from flagging themselves as duplicate.

~~Not currently working.~~

~~Idea is to have some unique value on the `TrafficManagerMod : IUserMod` (currently a `static int Build`, but could be on the instance instead) and pass that in to the mod checker so it can filter out "self" when scanning for offline mods.~~