### PR TITLE
Only perform logging in DEBUG builds

### DIFF
--- a/TLM/TLM/UI/TextureResources.cs
+++ b/TLM/TLM/UI/TextureResources.cs
@@ -272,9 +272,11 @@ namespace TrafficManager.UI
 
 			// Trim the index since 140 km/h / 90 MPH is the max sign we have
 			var upper = mph ? SpeedLimit.UPPER_MPH : SpeedLimit.UPPER_KMPH;
-			if (index > upper) {
+#if DEBUG
+            if (index > upper) {
 				Log.Info($"Trimming speed={speedLimit} index={index} to {upper}");
 			}
+#endif
 			var trimIndex = Math.Min(upper, Math.Max((ushort)0, index));
 			return textures[trimIndex];
 		}


### PR DESCRIPTION
If possible we should push out a 10.22 release with this fix; the issue completely grinds fps when there's a bunch of train tracks on-screen.

Edit: Thanks to @DaEgi01 for tracking down the issue!

Fixes #411