### PR TITLE
Various mod checker tweaks

### DIFF
--- a/TLM/TLM/TrafficManagerMod.cs
+++ b/TLM/TLM/TrafficManagerMod.cs
@@ -58,12 +58,9 @@ namespace TrafficManager
         }
 
         private static void CheckForIncompatibleMods()
-        {
-            if (GlobalConfig.Instance.Main.ScanForKnownIncompatibleModsAtStartup)
-            {
-                ModsCompatibilityChecker mcc = new ModsCompatibilityChecker();
-                mcc.PerformModCheck();
-            }
+        {   
+            ModsCompatibilityChecker mcc = new ModsCompatibilityChecker();
+            mcc.PerformModCheck();
         }
     }
 }

--- a/TLM/TLM/Util/ModsCompatibilityChecker.cs
+++ b/TLM/TLM/Util/ModsCompatibilityChecker.cs
@@ -75,16 +75,18 @@ namespace TrafficManager.Util {
 
             // iterate plugins
             foreach (PluginInfo mod in Singleton<PluginManager>.instance.GetPluginsInfo()) {
-                if (!mod.isBuiltin && !mod.isCameraScript && (!filterToEnabled || mod.isEnabled)) {
+                if (!mod.isBuiltin && !mod.isCameraScript) {
+
                     string modName = GetModName(mod);
                     ulong workshopID = mod.publishedFileID.AsUInt64;
 
-                    if (checkKnown && knownIncompatibleMods.ContainsKey(workshopID)) {
-                        // must be online workshop mod
+                    if (checkKnown && (!filterToEnabled || mod.isEnabled) && knownIncompatibleMods.ContainsKey(workshopID)) {
+
                         Log.Info($"Incompatible with: {workshopID} - {modName}");
                         results.Add(mod, modName);
+
                     } else if (modName.Contains("TM:PE") || modName.Contains("Traffic Manager")) {
-                        // It's a TM:PE build - either local or workshop
+
                         string workshopIDstr = workshopID == LOCAL_MOD ? "LOCAL" : workshopID.ToString();
                         Guid currentGuid = GetModGuid(mod);
 
@@ -92,6 +94,7 @@ namespace TrafficManager.Util {
                             Log.Info($"Detected conflicting '{modName}' (Workshop ID: {workshopIDstr}, GUID: {currentGuid}) in '{mod.modPath}'");
                             results.Add(mod, $"{modName} in /{Path.GetFileName(mod.modPath)}");
                         }
+
                     }
                 }
             }

--- a/TLM/TLM/Util/ModsCompatibilityChecker.cs
+++ b/TLM/TLM/Util/ModsCompatibilityChecker.cs
@@ -1,21 +1,21 @@
-using ColossalFramework;
-using ColossalFramework.Plugins;
-using ColossalFramework.UI;
-using CSUtil.Commons;
-using ICities;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Reflection;
-using TrafficManager.UI;
-using UnityEngine;
-using static ColossalFramework.Plugins.PluginManager;
+namespace TrafficManager.Util {
+    using ColossalFramework;
+    using ColossalFramework.Plugins;
+    using ColossalFramework.UI;
+    using CSUtil.Commons;
+    using ICities;
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Reflection;
+    using State;
+    using UI;
+    using UnityEngine;
+    using static ColossalFramework.Plugins.PluginManager;
 
-namespace TrafficManager.Util
-{
-    public class ModsCompatibilityChecker
-    {
-        public const ulong LOCAL_MOD = ulong.MaxValue;
+    public class ModsCompatibilityChecker {
+        // Game always uses ulong.MaxValue to depict local mods
+        private const ulong LOCAL_MOD = ulong.MaxValue;
 
         // Used for LoadIncompatibleModsList()
         private const string RESOURCES_PREFIX = "TrafficManager.Resources.";
@@ -24,22 +24,20 @@ namespace TrafficManager.Util
         // parsed contents of incompatible_mods.txt
         private readonly Dictionary<ulong, string> knownIncompatibleMods;
 
-        public ModsCompatibilityChecker()
-        {
-            knownIncompatibleMods = LoadListOfIncompatibleMods();
+        public ModsCompatibilityChecker() {
+            if (GlobalConfig.Instance.Main.ScanForKnownIncompatibleModsAtStartup) {
+                knownIncompatibleMods = LoadListOfIncompatibleMods();
+            }
         }
 
         /// <summary>
         /// Initiates scan for incompatible mods. If any found, and the user has enabled the mod checker, it creates and initialises the modal dialog panel.
         /// </summary>
-        public void PerformModCheck()
-        {
-            try
-            {
+        public void PerformModCheck() {
+            try {
                 Dictionary<PluginInfo, string> detected = ScanForIncompatibleMods();
 
-                if (detected.Count > 0)
-                {
+                if (detected.Count > 0) {
                     IncompatibleModsPanel panel = UIView.GetAView().AddUIComponent(typeof(IncompatibleModsPanel)) as IncompatibleModsPanel;
                     panel.IncompatibleMods = detected;
                     panel.Initialize();
@@ -47,8 +45,7 @@ namespace TrafficManager.Util
                     UIView.SetFocus(panel);
                 }
             }
-            catch (Exception e)
-            {
+            catch (Exception e) {
                 Log.Info("Something went wrong while checking incompatible mods - see main game log for details.");
                 Debug.LogException(e);
             }
@@ -62,8 +59,7 @@ namespace TrafficManager.Util
         /// 
         /// <exception cref="ArgumentException">Invalid folder path (contains invalid characters, is empty, or contains only white spaces).</exception>
         /// <exception cref="PathTooLongException">Path is too long (longer than the system-defined maximum length).</exception>
-        public Dictionary<PluginInfo, string> ScanForIncompatibleMods()
-        {
+        public Dictionary<PluginInfo, string> ScanForIncompatibleMods() {
             Guid selfGuid = Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId;
 
             Log.Info($"Scanning for incompatible mods; My GUID = {selfGuid}");
@@ -71,35 +67,28 @@ namespace TrafficManager.Util
             // list of installed incompatible mods
             Dictionary<PluginInfo, string> results = new Dictionary<PluginInfo, string>();
 
+            // check known incompatible mods? (incompatible_mods.txt)
+            bool checkKnown = GlobalConfig.Instance.Main.ScanForKnownIncompatibleModsAtStartup;
+
             // only check enabled mods?
-            bool filterToEnabled = State.GlobalConfig.Instance.Main.IgnoreDisabledMods;
+            bool filterToEnabled = GlobalConfig.Instance.Main.IgnoreDisabledMods;
 
             // iterate plugins
-            foreach (PluginInfo mod in Singleton<PluginManager>.instance.GetPluginsInfo())
-            {
-                if (!mod.isBuiltin && !mod.isCameraScript && (!filterToEnabled || mod.isEnabled))
-                {
+            foreach (PluginInfo mod in Singleton<PluginManager>.instance.GetPluginsInfo()) {
+                if (!mod.isBuiltin && !mod.isCameraScript && (!filterToEnabled || mod.isEnabled)) {
                     string modName = GetModName(mod);
                     ulong workshopID = mod.publishedFileID.AsUInt64;
 
-                    if (knownIncompatibleMods.ContainsKey(workshopID))
-                    {
+                    if (checkKnown && knownIncompatibleMods.ContainsKey(workshopID)) {
                         // must be online workshop mod
                         Log.Info($"Incompatible with: {workshopID} - {modName}");
                         results.Add(mod, modName);
-                    }
-                    else if (modName.Contains("TM:PE") || modName.Contains("Traffic Manager"))
-                    {
+                    } else if (modName.Contains("TM:PE") || modName.Contains("Traffic Manager")) {
                         // It's a TM:PE build - either local or workshop
                         string workshopIDstr = workshopID == LOCAL_MOD ? "LOCAL" : workshopID.ToString();
                         Guid currentGuid = GetModGuid(mod);
 
-                        if (currentGuid == selfGuid)
-                        {
-                            Log.Info($"Found myself: '{modName}' (Workshop ID: {workshopIDstr}, GUID: {currentGuid}) in '{mod.modPath}'");
-                        }
-                        else
-                        {
+                        if (currentGuid != selfGuid) {
                             Log.Info($"Detected conflicting '{modName}' (Workshop ID: {workshopIDstr}, GUID: {currentGuid}) in '{mod.modPath}'");
                             results.Add(mod, $"{modName} in /{Path.GetFileName(mod.modPath)}");
                         }
@@ -121,8 +110,7 @@ namespace TrafficManager.Util
         /// <param name="plugin">The <see cref="PluginInfo"/> associated with the mod.</param>
         /// 
         /// <returns>The name of the specified plugin.</returns>
-        public string GetModName(PluginInfo plugin)
-        {
+        public string GetModName(PluginInfo plugin) {
             return ((IUserMod)plugin.userModInstance).Name;
         }
 
@@ -133,8 +121,7 @@ namespace TrafficManager.Util
         /// <param name="plugin">The <see cref="PluginInfo"/> associated with the mod.</param>
         /// 
         /// <returns>The <see cref="Guid"/> of the mod.</returns>
-        public Guid GetModGuid(PluginInfo plugin)
-        {
+        public Guid GetModGuid(PluginInfo plugin) {
             return plugin.userModInstance.GetType().Assembly.ManifestModule.ModuleVersionId;
         }
 
@@ -143,17 +130,14 @@ namespace TrafficManager.Util
         /// </summary>
         /// 
         /// <returns>A dictionary of mod names referenced by Steam Workshop ID.</returns>
-        private Dictionary<ulong, string> LoadListOfIncompatibleMods()
-        {
+        private Dictionary<ulong, string> LoadListOfIncompatibleMods() {
             // list of known incompatible mods
             Dictionary<ulong, string> results = new Dictionary<ulong, string>();
 
             // load the file
             string[] lines;
-            using (Stream st = Assembly.GetExecutingAssembly().GetManifestResourceStream(RESOURCES_PREFIX + INCOMPATIBLE_MODS_FILE))
-            {
-                using (StreamReader sr = new StreamReader(st))
-                {
+            using (Stream st = Assembly.GetExecutingAssembly().GetManifestResourceStream(RESOURCES_PREFIX + INCOMPATIBLE_MODS_FILE)) {
+                using (StreamReader sr = new StreamReader(st)) {
                     lines = sr.ReadToEnd().Split(new string[] { "\n", "\r\n" }, StringSplitOptions.None);
                 }
             }
@@ -161,12 +145,10 @@ namespace TrafficManager.Util
             Log.Info($"{RESOURCES_PREFIX}{INCOMPATIBLE_MODS_FILE} contains {lines.Length} entries");
 
             // parse the file
-            for (int i = 0; i < lines.Length; i++)
-            {
+            for (int i = 0; i < lines.Length; i++) {
                 ulong steamId;
                 string[] strings = lines[i].Split(';');
-                if (ulong.TryParse(strings[0], out steamId))
-                {
+                if (ulong.TryParse(strings[0], out steamId)) {
                     results.Add(steamId, strings[1]);
                 }
             }

--- a/TLM/TLM/Util/ModsCompatibilityChecker.cs
+++ b/TLM/TLM/Util/ModsCompatibilityChecker.cs
@@ -88,7 +88,7 @@ namespace TrafficManager.Util {
 
                         strIncompatible = "!";
                         if (checkKnown && (!filterToEnabled || mod.isEnabled)) {
-                            Log.Warning("[TM:PE] Incompatible mod detected: " + strModName);
+                            Debug.Log("[TM:PE] Incompatible mod detected: " + strModName);
                             results.Add(mod, strModName);
                         }
 
@@ -97,7 +97,7 @@ namespace TrafficManager.Util {
                         if (GetModGuid(mod) != selfGuid) {
                             string strFolder = Path.GetFileName(mod.modPath);
                             strIncompatible = "!";
-                            Log.Warning("[TM:PE] Duplicate instance detected: " + strModName + " in " + strFolder);
+                            Debug.Log("[TM:PE] Duplicate instance detected: " + strModName + " in " + strFolder);
                             results.Add(mod, strModName + " /" + strFolder);
                         }
 

--- a/TLM/TLM/Util/ModsCompatibilityChecker.cs
+++ b/TLM/TLM/Util/ModsCompatibilityChecker.cs
@@ -104,7 +104,6 @@ namespace TrafficManager.Util {
                     }
 
                     logStr += $"{strIncompatible} {strEnabled} {strWorkshopId.PadRight(12)} {strModName}\n";
-
                 }
             }
 
@@ -155,16 +154,17 @@ namespace TrafficManager.Util {
                 }
             }
 
-            Log.Info($"{RESOURCES_PREFIX}{INCOMPATIBLE_MODS_FILE} contains {lines.Length} entries");
-
             // parse the file
             for (int i = 0; i < lines.Length; i++) {
-                ulong steamId;
-                string[] strings = lines[i].Split(';');
-                if (ulong.TryParse(strings[0], out steamId)) {
-                    results.Add(steamId, strings[1]);
+                if (!string.IsNullOrEmpty(lines[i])) {
+                    string[] strings = lines[i].Split(';');
+                    if (ulong.TryParse(strings[0], out ulong steamId)) {
+                        results.Add(steamId, strings[1]);
+                    }
                 }
             }
+
+            Log.Info($"{RESOURCES_PREFIX}{INCOMPATIBLE_MODS_FILE} contains {results.Count} entries");
 
             return results;
         }


### PR DESCRIPTION
Most common issue these days is TMPE not loading settings because there's more than one instance installed.

Always check (and warn if found) for duplicate TM:PE, regardless of user settings.

Fixes #434 

Ignores blank lines in `incompatible_mods.txt` resource.

Fixes #441 

Also refactored to new code style guidelines.