### PR TITLE
Make it impossible to use TRACE option without DEBUG

### DIFF
--- a/TLM/CSUtil.Commons/CSUtil.Commons.csproj
+++ b/TLM/CSUtil.Commons/CSUtil.Commons.csproj
@@ -28,7 +28,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants></DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>..\TMPE.ruleset</CodeAnalysisRuleSet>

--- a/TLM/CSUtil.Commons/Log.cs
+++ b/TLM/CSUtil.Commons/Log.cs
@@ -5,6 +5,12 @@
     using System.Threading;
     using UnityEngine;
 
+#if !DEBUG
+    #if TRACE
+        #error TRACE is defined outside of a DEBUG build, please remove
+    #endif
+#endif
+
     public static class Log {
         private static readonly object LogLock = new object();
 


### PR DESCRIPTION
Produces compile error if TRACE is defined but DEBUG is not defined
Fixes #454 