### PR TITLE
Change `static` to `const`

### DIFF
--- a/TLM/TLM/TrafficManagerMod.cs
+++ b/TLM/TLM/TrafficManagerMod.cs
@@ -9,23 +9,23 @@ namespace TrafficManager
 {
     public class TrafficManagerMod : IUserMod
     {
-        public static readonly uint GameVersion = 184803856u;
-        public static readonly uint GameVersionA = 1u;
-        public static readonly uint GameVersionB = 12u;
-        public static readonly uint GameVersionC = 1u;
-        public static readonly uint GameVersionBuild = 2u;
+        public const uint GameVersion = 184803856u;
+        public const uint GameVersionA = 1u;
+        public const uint GameVersionB = 12u;
+        public const uint GameVersionC = 1u;
+        public const uint GameVersionBuild = 2u;
 
-        public static readonly string Version = "11.0-alpha3";
+        public const string Version = "11.0-alpha4";
 
 #if LABS
-        public static readonly string Branch = "LABS";
+        public const string Branch = "LABS";
 #elif DEBUG
-        public static readonly string Branch = "DEBUG";
+        public const string Branch = "DEBUG";
 #else
-        public static readonly string Branch = "STABLE";
+        public const string Branch = "STABLE";
 #endif
 
-        public static readonly string ModName = "TM:PE " + Version + " " + Branch;
+        public const string ModName = "TM:PE " + Branch + " " + Version;
 
         public string Name => ModName;
 

--- a/TLM/TLM/TrafficManagerMod.cs
+++ b/TLM/TLM/TrafficManagerMod.cs
@@ -9,14 +9,6 @@ namespace TrafficManager
 {
     public class TrafficManagerMod : IUserMod
     {
-        public const uint GameVersion = 184803856u;
-        public const uint GameVersionA = 1u;
-        public const uint GameVersionB = 12u;
-        public const uint GameVersionC = 1u;
-        public const uint GameVersionBuild = 2u;
-
-        public const string Version = "11.0-alpha4";
-
 #if LABS
         public const string Branch = "LABS";
 #elif DEBUG
@@ -25,7 +17,15 @@ namespace TrafficManager
         public const string Branch = "STABLE";
 #endif
 
-        public const string ModName = "TM:PE " + Branch + " " + Version;
+        public static readonly uint GameVersion = 184803856u;
+        public static readonly uint GameVersionA = 1u;
+        public static readonly uint GameVersionB = 12u;
+        public static readonly uint GameVersionC = 1u;
+        public static readonly uint GameVersionBuild = 2u;
+
+        public static readonly string Version = "11.0-alpha4";
+
+        public static readonly string ModName = "TM:PE " + Branch + " " + Version;
 
         public string Name => ModName;
 

--- a/TLM/TLM/UI/MainMenu/VersionLabel.cs
+++ b/TLM/TLM/UI/MainMenu/VersionLabel.cs
@@ -1,20 +1,12 @@
-using ColossalFramework.UI;
-using UnityEngine;
-
 namespace TrafficManager.UI.MainMenu {
+    using ColossalFramework.UI;
+    using UnityEngine;
+
     public class VersionLabel : UILabel {
         public override void Start() {
             size = new Vector2(MainMenuPanel.SIZE_PROFILES[0].MENU_WIDTH, MainMenuPanel.SIZE_PROFILES[0].TOP_BORDER); // TODO use current size profile
-
-#if LABS
-            text = "TM:PE " + TrafficManagerMod.Version + " LABS";
-#elif DEBUG
-            text = "TM:PE " + TrafficManagerMod.Version + " DEBUG";
-#else // STABLE
-            text = "TM:PE " + TrafficManagerMod.Version + " STABLE";
-#endif
+            text = TrafficManagerMod.ModName;
             relativePosition = new Vector3(5f, 5f);
-
             textAlignment = UIHorizontalAlignment.Left;
         }
     }


### PR DESCRIPTION
Quoting @dymanoid : 

> It's better to use `const string` instead of `static readonly string`.  
> ... `const string` is a cheaper and faster version of `static readonly string`.  
> It's not much about performance, but rather about semantics. You probably should not change everything to `const`, but the values that are real constants should be `const`. [Read e.g. here](https://stackoverflow.com/questions/4402690/declaring-strings-public-static-readonly-versus-public-const-versus-public-stati/4403089#4403089). The version number could be `static readonly` because it changes from version to version and could be used by external assemblies, but the `"LABS"` string is a constant in the whole TMPE universe, so use const for that.