### PR TITLE
Prevent usage of 'in' with non-readonly structs by a compiler error

### DIFF
--- a/TLM/CSUtil.Commons/CSUtil.Commons.csproj
+++ b/TLM/CSUtil.Commons/CSUtil.Commons.csproj
@@ -81,6 +81,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Analyzer Include="..\packages\ReflectionIT.Analyzer.Structs.0.1.0\analyzers\dotnet\cs\ReflectionIT.Analyzer.Structs.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>

--- a/TLM/CSUtil.Commons/packages.config
+++ b/TLM/CSUtil.Commons/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ReflectionIT.Analyzer.Structs" version="0.1.0" targetFramework="net35" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net35" developmentDependency="true" />
 </packages>

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -436,6 +436,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Analyzer Include="..\packages\ReflectionIT.Analyzer.Structs.0.1.0\analyzers\dotnet\cs\ReflectionIT.Analyzer.Structs.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>

--- a/TLM/TLM/packages.config
+++ b/TLM/TLM/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ReflectionIT.Analyzer.Structs" version="0.1.0" targetFramework="net35" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net35" developmentDependency="true" />
 </packages>

--- a/TLM/TMPE.CitiesGameBridge/TMPE.CitiesGameBridge.csproj
+++ b/TLM/TMPE.CitiesGameBridge/TMPE.CitiesGameBridge.csproj
@@ -92,6 +92,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Analyzer Include="..\packages\ReflectionIT.Analyzer.Structs.0.1.0\analyzers\dotnet\cs\ReflectionIT.Analyzer.Structs.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>

--- a/TLM/TMPE.CitiesGameBridge/packages.config
+++ b/TLM/TMPE.CitiesGameBridge/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ReflectionIT.Analyzer.Structs" version="0.1.0" targetFramework="net35" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net35" developmentDependency="true" />
 </packages>

--- a/TLM/TMPE.GenericGameBridge/TMPE.GenericGameBridge.csproj
+++ b/TLM/TMPE.GenericGameBridge/TMPE.GenericGameBridge.csproj
@@ -84,6 +84,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Analyzer Include="..\packages\ReflectionIT.Analyzer.Structs.0.1.0\analyzers\dotnet\cs\ReflectionIT.Analyzer.Structs.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>

--- a/TLM/TMPE.GenericGameBridge/packages.config
+++ b/TLM/TMPE.GenericGameBridge/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ReflectionIT.Analyzer.Structs" version="0.1.0" targetFramework="net35" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net35" developmentDependency="true" />
 </packages>

--- a/TLM/TMPE.TestGameBridge/TMPE.TestGameBridge.csproj
+++ b/TLM/TMPE.TestGameBridge/TMPE.TestGameBridge.csproj
@@ -69,6 +69,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Analyzer Include="..\packages\ReflectionIT.Analyzer.Structs.0.1.0\analyzers\dotnet\cs\ReflectionIT.Analyzer.Structs.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>

--- a/TLM/TMPE.TestGameBridge/packages.config
+++ b/TLM/TMPE.TestGameBridge/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ReflectionIT.Analyzer.Structs" version="0.1.0" targetFramework="net35" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net35" developmentDependency="true" />
 </packages>

--- a/TLM/TMPE.UnitTest/TMPE.UnitTest.csproj
+++ b/TLM/TMPE.UnitTest/TMPE.UnitTest.csproj
@@ -107,6 +107,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Analyzer Include="..\packages\ReflectionIT.Analyzer.Structs.0.1.0\analyzers\dotnet\cs\ReflectionIT.Analyzer.Structs.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>

--- a/TLM/TMPE.UnitTest/packages.config
+++ b/TLM/TMPE.UnitTest/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ReflectionIT.Analyzer.Structs" version="0.1.0" targetFramework="net35" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net35" developmentDependency="true" />
 </packages>

--- a/TLM/TMPE.ruleset
+++ b/TLM/TMPE.ruleset
@@ -1,5 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Rules for TLM" Description="Code analysis rules for TLM" ToolsVersion="15.0">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Rules for TLM" Description="Code analysis rules for TLM" ToolsVersion="16.0">
+  <Rules AnalyzerId="ReflectionIT.Analyzer.Structs" RuleNamespace="ReflectionIT.Analyzer.Structs">
+    <Rule Id="RAS0001" Action="Error" />
+  </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SA1000" Action="None" />
     <Rule Id="SA1005" Action="None" />


### PR DESCRIPTION
Using a Roslyn Analyzer [ReflectionIT.Analyzer.Structs](https://www.nuget.org/packages/ReflectionIT.Analyzer.Structs/), issue a compiler error when a non-`readonly` struct is passed to a method using the `in` modifier.

Passing a non-readonly struct with an `in` modifier can drastically decrease performance, because in the called method, the compiler will create defensive struct copies on every method call or property access of that passed struct.

Closes krzychu124/Cities-Skylines-Traffic-Manager-President-Edition#440.