### PR TITLE
Eliminate vehicle pause before entering junction if has right of way

### DIFF
--- a/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
+++ b/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
@@ -1492,7 +1492,7 @@
 
                     var sign = prioMan.GetPrioritySign(prevPos.m_segment, isTargetStartNode);
 
-                    if (sign != PriorityType.None) {
+                    if (sign != PriorityType.None && sign != PriorityType.Main) {
                         if (logPriority) {
                             Log._DebugFormat(
                                 "VehicleBehaviorManager.MayChangeSegment({0}): Vehicle is arriving " +


### PR DESCRIPTION
Fixes #448 
- skip checking if vehicle has the right of way.