### PR TITLE
Cargo Info mod is incompatible

### DIFF
--- a/TLM/TLM/Resources/incompatible_mods.txt
+++ b/TLM/TLM/Resources/incompatible_mods.txt
@@ -44,3 +44,4 @@
 408209297;Extended Road Upgrade
 417926819;Road Assistant
 631930385;Realistic Vehicle Speeds
+1072157697;Cargo Info


### PR DESCRIPTION
The mod is not compatible since Industries release. Breaks vehicle spawning on highways, also causes `array index out of range` error.

Related troubleshooting guides:

* [Outside Connections not Working](https://github.com/krzychu124/Cities-Skylines-Traffic-Manager-President-Edition/wiki/Outside-connections-not-working)
* [Array Index - Symptom 7](https://github.com/krzychu124/Cities-Skylines-Traffic-Manager-President-Edition/wiki/Array-Index---Symptom-7)