### PR TITLE
Tool overlay render optimisations

### DIFF
--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -265,6 +265,8 @@
     <Compile Include="State\Flags.cs" />
     <Compile Include="UI\TransportDemandViewMode.cs" />
     <Compile Include="UI\UITransportDemand.cs" />
+    <Compile Include="Util\Caching\CameraTransformValue.cs" />
+    <Compile Include="Util\Caching\GenericArrayCache.cs" />
     <Compile Include="Util\FloatUtil.cs" />
     <Compile Include="Util\GenericObservable.cs" />
     <Compile Include="Util\GenericUnsubscriber.cs" />

--- a/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
@@ -43,12 +43,12 @@
         /// <summary>
         /// Stores potentially visible ids for nodes while the camera did not move
         /// </summary>
-        private GenericArrayCache<uint> CacheVisibleNodeIds { get; }
+        private GenericArrayCache<uint> CachedVisibleNodeIds { get; }
 
         /// <summary>
-        /// Stores last cached camera position in <see cref="CacheVisibleNodeIds"/>
+        /// Stores last cached camera position in <see cref="CachedVisibleNodeIds"/>
         /// </summary>
-        private CameraTransformValue LastCachedCamera;
+        private CameraTransformValue LastCachedCamera { get; set; }
 
         private class NodeLaneMarker {
             internal ushort SegmentId;
@@ -75,7 +75,7 @@
             // Log._Debug($"LaneConnectorTool: Constructor called");
             currentNodeMarkers = new Dictionary<ushort, List<NodeLaneMarker>>();
 
-            CacheVisibleNodeIds = new GenericArrayCache<uint>(NetManager.MAX_NODE_COUNT);
+            CachedVisibleNodeIds = new GenericArrayCache<uint>(NetManager.MAX_NODE_COUNT);
             LastCachedCamera = new CameraTransformValue();
         }
 
@@ -120,7 +120,7 @@
             // Assumption: The states checked in this loop don't change while the tool is active
             var currentCameraState = new CameraTransformValue(currentCamera);
             if (!LastCachedCamera.Equals(currentCameraState)) {
-                CacheVisibleNodeIds.Clear();
+                CachedVisibleNodeIds.Clear();
                 LastCachedCamera = currentCameraState;
 
                 for (uint nodeId = 1; nodeId < NetManager.MAX_NODE_COUNT; ++nodeId) {
@@ -155,12 +155,12 @@
                     }
 
                     // Add
-                    CacheVisibleNodeIds.Add(nodeId);
+                    CachedVisibleNodeIds.Add(nodeId);
                 }
             }
 
-            for (int cacheIndex = CacheVisibleNodeIds.Size - 1; cacheIndex >= 0; cacheIndex--) {
-                var nodeId = CacheVisibleNodeIds.Values[cacheIndex];
+            for (int cacheIndex = CachedVisibleNodeIds.Size - 1; cacheIndex >= 0; cacheIndex--) {
+                var nodeId = CachedVisibleNodeIds.Values[cacheIndex];
 
                 List<NodeLaneMarker> nodeMarkers;
                 bool hasMarkers = currentNodeMarkers.TryGetValue((ushort)nodeId, out nodeMarkers);

--- a/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
@@ -151,11 +151,13 @@
             Transform currentCameraTransform = Camera.main.transform;
             Vector3 camPos = currentCameraTransform.position;
 
-            if (!LastCachedCamera.Equals(currentCamera))
-            {
+            if (!LastCachedCamera.Equals(currentCamera)) {
                 // cache visible segments
                 LastCachedCamera = currentCamera;
                 CachedVisibleSegmentIds.Clear();
+
+                const float MAX_DIST = TrafficManagerTool.MAX_OVERLAY_DISTANCE *
+                                       TrafficManagerTool.MAX_OVERLAY_DISTANCE;
 
                 for (uint segmentId = 1; segmentId < NetManager.MAX_SEGMENT_COUNT; ++segmentId) {
                     if (!Constants.ServiceFactory.NetService.IsSegmentValid((ushort)segmentId)) {
@@ -164,8 +166,8 @@
 
                     // if ((netManager.m_segments.m_buffer[segmentId].m_flags &
                     // NetSegment.Flags.Untouchable) != NetSegment.Flags.None) continue;
-                    if ((netManager.m_segments.m_buffer[segmentId].m_bounds.center - camPos)
-                        .magnitude > TrafficManagerTool.MAX_OVERLAY_DISTANCE) {
+                    Vector3 distToCamera = netManager.m_segments.m_buffer[segmentId].m_bounds.center - camPos;
+                    if (distToCamera.sqrMagnitude > MAX_DIST) {
                         continue; // do not draw if too distant
                     }
 

--- a/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
@@ -12,6 +12,7 @@
     using Traffic;
     using UnityEngine;
     using Util;
+    using Util.Caching;
 
     public class SpeedLimitsTool : SubTool {
         public const int
@@ -44,7 +45,17 @@
             TrafficManagerTool.MoveGUI(new Rect(0, 0, 10 * (GUI_SPEED_SIGN_SIZE + 5), 150));
 
         private Rect defaultsWindowRect = TrafficManagerTool.MoveGUI(new Rect(0, 80, 50, 50));
-        private readonly HashSet<ushort> currentlyVisibleSegmentIds;
+
+        /// <summary>
+        /// Stores potentially visible segment ids while the camera did not move
+        /// </summary>
+        private GenericArrayCache<ushort> CachedVisibleSegmentIds { get; }
+
+        /// <summary>
+        /// Stores last cached camera position in <see cref="CachedVisibleSegmentIds"/>
+        /// </summary>
+        private CameraTransformValue LastCachedCamera { get; set; }
+
         private bool defaultsWindowVisible;
         private int currentInfoIndex = -1;
         private SpeedValue currentSpeedLimit = new SpeedValue(-1f);
@@ -65,7 +76,8 @@
         public SpeedLimitsTool(TrafficManagerTool mainTool)
             : base(mainTool)
         {
-            currentlyVisibleSegmentIds = new HashSet<ushort>();
+            CachedVisibleSegmentIds = new GenericArrayCache<ushort>(NetManager.MAX_SEGMENT_COUNT);
+            LastCachedCamera = new CameraTransformValue();
         }
 
         public override bool IsCursorInPanel() {
@@ -100,7 +112,7 @@
                 defaultsWindowRect = GUILayout.Window(
                     258,
                     defaultsWindowRect,
-                    _guiDefaultsWindow,
+                    GuiDefaultsWindow,
                     Translation.GetString("Default_speed_limits"),
                     WindowStyle);
             }
@@ -126,30 +138,24 @@
 
         public override void Cleanup() {
             segmentCenterByDir.Clear();
-            currentlyVisibleSegmentIds.Clear();
-            lastCamPos = null;
-            lastCamRot = null;
+            CachedVisibleSegmentIds.Clear();
             currentInfoIndex = -1;
             currentSpeedLimit = new SpeedValue(-1f);
         }
 
-        private Quaternion? lastCamRot;
-        private Vector3? lastCamPos;
-
         private void ShowSigns(bool viewOnly) {
-            Quaternion camRot = Camera.main.transform.rotation;
-            Vector3 camPos = Camera.main.transform.position;
-
             NetManager netManager = Singleton<NetManager>.instance;
             SpeedLimitManager speedLimitManager = SpeedLimitManager.Instance;
 
-            if (lastCamPos == null
-                || lastCamRot == null
-                || !lastCamRot.Equals(camRot)
-                || !lastCamPos.Equals(camPos))
+            var currentCamera = new CameraTransformValue(Camera.main);
+            Transform currentCameraTransform = Camera.main.transform;
+            Vector3 camPos = currentCameraTransform.position;
+
+            if (!LastCachedCamera.Equals(currentCamera))
             {
                 // cache visible segments
-                currentlyVisibleSegmentIds.Clear();
+                LastCachedCamera = currentCamera;
+                CachedVisibleSegmentIds.Clear();
 
                 for (uint segmentId = 1; segmentId < NetManager.MAX_SEGMENT_COUNT; ++segmentId) {
                     if (!Constants.ServiceFactory.NetService.IsSegmentValid((ushort)segmentId)) {
@@ -177,32 +183,23 @@
                         continue;
                     }
 
-                    currentlyVisibleSegmentIds.Add((ushort)segmentId);
+                    CachedVisibleSegmentIds.Add((ushort)segmentId);
                 } // end for all segments
-
-                lastCamPos = camPos;
-                lastCamRot = camRot;
             }
 
-            bool handleHovered = false;
-
-            foreach (ushort segmentId in currentlyVisibleSegmentIds) {
-                bool visible = MainTool.WorldToScreenPoint(
-                    netManager.m_segments.m_buffer[segmentId].m_bounds.center,
-                    out Vector3 _);
-
-                if (!visible) {
-                    continue;
-                }
-
+            for (int segmentIdIndex = CachedVisibleSegmentIds.Size - 1;
+                 segmentIdIndex >= 0;
+                 segmentIdIndex--)
+            {
+                ushort segmentId = CachedVisibleSegmentIds.Values[segmentIdIndex];
                 // draw speed limits
-                if (MainTool.GetToolMode() == ToolMode.VehicleRestrictions &&
-                    segmentId == SelectedSegmentId) {
+                if ((MainTool.GetToolMode() == ToolMode.VehicleRestrictions) &&
+                    (segmentId == SelectedSegmentId)) {
                     continue;
                 }
 
                 // no speed limit overlay on selected segment when in vehicle restrictions mode
-                drawSpeedLimitHandles(
+                DrawSpeedLimitHandles(
                     segmentId,
                     ref netManager.m_segments.m_buffer[segmentId],
                     viewOnly,
@@ -214,10 +211,10 @@
         /// The window for setting the defaullt speeds per road type
         /// </summary>
         /// <param name="num"></param>
-        private void _guiDefaultsWindow(int num) {
+        private void GuiDefaultsWindow(int num) {
             List<NetInfo> mainNetInfos = SpeedLimitManager.Instance.GetCustomizableNetInfos();
 
-            if (mainNetInfos == null || mainNetInfos.Count <= 0) {
+            if ((mainNetInfos == null) || (mainNetInfos.Count <= 0)) {
                 Log._Debug($"mainNetInfos={mainNetInfos?.Count}");
                 DragWindow(ref defaultsWindowRect);
                 return;
@@ -225,7 +222,7 @@
 
             bool updateRoadTex = false;
 
-            if (currentInfoIndex < 0 || currentInfoIndex >= mainNetInfos.Count) {
+            if ((currentInfoIndex < 0) || (currentInfoIndex >= mainNetInfos.Count)) {
                 currentInfoIndex = 0;
                 updateRoadTex = true;
                 Log._Debug($"set currentInfoIndex to 0");
@@ -258,7 +255,7 @@
 
             if (GUILayout.Button("←", GUILayout.Width(50))) {
                 currentInfoIndex =
-                    (currentInfoIndex + mainNetInfos.Count - 1) % mainNetInfos.Count;
+                    ((currentInfoIndex + mainNetInfos.Count) - 1) % mainNetInfos.Count;
                 info = mainNetInfos[currentInfoIndex];
                 currentSpeedLimit = new SpeedValue(
                     SpeedLimitManager.Instance.GetCustomNetInfoSpeedLimit(info));
@@ -392,14 +389,14 @@
 
         private void UpdateRoadTex(NetInfo info) {
             if (info != null) {
-                if (info.m_Atlas != null && info.m_Atlas.material != null &&
-                    info.m_Atlas.material.mainTexture != null &&
+                if ((info.m_Atlas != null) && (info.m_Atlas.material != null) &&
+                    (info.m_Atlas.material.mainTexture != null) &&
                     info.m_Atlas.material.mainTexture is Texture2D mainTex)
                 {
                     UITextureAtlas.SpriteInfo spriteInfo = info.m_Atlas[info.m_Thumbnail];
 
-                    if (spriteInfo != null && spriteInfo.texture != null &&
-                        spriteInfo.texture.width > 0 && spriteInfo.texture.height > 0) {
+                    if ((spriteInfo != null) && (spriteInfo.texture != null) &&
+                        (spriteInfo.texture.width > 0) && (spriteInfo.texture.height > 0)) {
                         try {
                             roadTexture = new Texture2D(
                                 spriteInfo.texture.width,
@@ -544,18 +541,17 @@
             GUILayout.EndVertical();
         }
 
-        private bool drawSpeedLimitHandles(ushort segmentId,
+        private void DrawSpeedLimitHandles(ushort segmentId,
                                            ref NetSegment segment,
                                            bool viewOnly,
                                            ref Vector3 camPos)
         {
             if (viewOnly && !Options.speedLimitsOverlay) {
-                return false;
+                return;
             }
 
             Vector3 center = segment.m_bounds.center;
             NetManager netManager = Singleton<NetManager>.instance;
-            var hovered = false;
             SpeedValue speedLimitToSet = viewOnly
                                              ? new SpeedValue(-1f)
                                              : currentPaletteSpeedLimit;
@@ -585,7 +581,7 @@
                 // if ((segment.m_flags & NetSegment.Flags.Invert) == NetSegment.Flags.None) {
                 //        xu = -xu; }
                 float f = viewOnly ? 4f : 7f; // reserved sign size in game coordinates
-                Vector3 zero = center - (0.5f * (numLanes - 1 + numDirections - 1) * f * xu);
+                Vector3 zero = center - (0.5f * (((numLanes - 1) + numDirections) - 1) * f * xu);
 
                 uint x = 0;
                 IList<LanePos> sortedLanes = Constants.ServiceFactory.NetService.GetSortedLanes(
@@ -645,8 +641,8 @@
 
                     if (!viewOnly
                         && !onlyMonorailLanes
-                        && (laneInfo.m_vehicleType & VehicleInfo.VehicleType.Monorail) !=
-                        VehicleInfo.VehicleType.None)
+                        && ((laneInfo.m_vehicleType & VehicleInfo.VehicleType.Monorail) !=
+                            VehicleInfo.VehicleType.None))
                     {
                         Texture2D tex1 = RoadUITextures.VehicleInfoSignTextures[
                             LegacyExtVehicleType.ToNew(ExtVehicleType.PassengerTrain)];
@@ -662,9 +658,7 @@
                             speedLimitSignSize);
                     }
 
-                    if (hoveredHandle) {
-                        hovered = true;
-                    }
+                    if (hoveredHandle) { }
 
                     if (hoveredHandle && Input.GetMouseButton(0) && !IsCursorInPanel()) {
                         SpeedLimitManager.Instance.SetSpeedLimit(
@@ -735,7 +729,7 @@
                         continue;
                     }
 
-                    float zoom = 1.0f / (e.Value - camPos).magnitude * 100f * MainTool.GetBaseZoom();
+                    float zoom = (1.0f / (e.Value - camPos).magnitude) * 100f * MainTool.GetBaseZoom();
                     float size = (viewOnly ? 0.8f : 1f) * speedLimitSignSize * zoom;
                     Color guiColor = GUI.color;
                     var boundingBox = new Rect(screenPos.x - (size / 2),
@@ -748,7 +742,6 @@
 
                     if (hoveredHandle) {
                         // mouse hovering over sign
-                        hovered = true;
                     }
 
                     // Draw something right here, the road sign texture
@@ -799,9 +792,9 @@
 
                                     NetInfo.Direction otherNormDir = laneInfo.m_finalDirection;
 
-                                    if ((netManager.m_segments.m_buffer[otherSegmentId].m_flags
-                                         & NetSegment.Flags.Invert)
-                                        != NetSegment.Flags.None ^ reverse)
+                                    if (((netManager.m_segments.m_buffer[otherSegmentId].m_flags
+                                          & NetSegment.Flags.Invert)
+                                         != NetSegment.Flags.None) ^ reverse)
                                     {
                                         otherNormDir = NetInfo.InvertDirection(otherNormDir);
                                     }
@@ -822,8 +815,6 @@
                     GUI.color = guiColor;
                 }
             }
-
-            return hovered;
         }
 
         public static string ToMphPreciseString(SpeedValue speed) {
@@ -948,7 +939,7 @@
         /// <returns>Multiplier for horizontal sign size</returns>
         public static float GetVerticalTextureScale() {
             return (GlobalConfig.Instance.Main.DisplaySpeedLimitsMph &&
-                    GlobalConfig.Instance.Main.MphRoadSignStyle == MphSignStyle.SquareUS)
+                    (GlobalConfig.Instance.Main.MphRoadSignStyle == MphSignStyle.SquareUS))
                        ? 1.25f
                        : 1.0f;
         }

--- a/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
@@ -84,7 +84,9 @@
             return base.IsCursorInPanel() || cursorInSecondaryPanel;
         }
 
-        public override void OnActivate() { }
+        public override void OnActivate() {
+            LastCachedCamera = new CameraTransformValue();
+        }
 
         public override void OnPrimaryClickOverlay() { }
 

--- a/TLM/TLM/UI/SubTools/VehicleRestrictionsTool.cs
+++ b/TLM/TLM/UI/SubTools/VehicleRestrictionsTool.cs
@@ -109,7 +109,7 @@
                 windowRect = GUILayout.Window(
                     255,
                     windowRect,
-                    _guiVehicleRestrictionsWindow,
+                    GuiVehicleRestrictionsWindow,
                     Translation.GetString("Vehicle_restrictions"),
                     WindowStyle);
                 cursorInSecondaryPanel = windowRect.Contains(Event.current.mousePosition);
@@ -177,7 +177,7 @@
                 }
 
                 // draw vehicle restrictions
-                if (drawVehicleRestrictionHandles(
+                if (DrawVehicleRestrictionHandles(
                     segmentId,
                     ref netManager.m_segments.m_buffer[segmentId],
                     viewOnly || segmentId != SelectedSegmentId,
@@ -197,7 +197,7 @@
             }
         }
 
-        private void _guiVehicleRestrictionsWindow(int num) {
+        private void GuiVehicleRestrictionsWindow(int num) {
             NetSegment[] segmentsBuffer = Singleton<NetManager>.instance.m_segments.m_buffer;
 
             if (GUILayout.Button(Translation.GetString("Invert"))) {
@@ -406,7 +406,7 @@
                 LaneVisitorFun);
         }
 
-        private bool drawVehicleRestrictionHandles(ushort segmentId,
+        private bool DrawVehicleRestrictionHandles(ushort segmentId,
                                                    ref NetSegment segment,
                                                    bool viewOnly,
                                                    out bool stateUpdated) {

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -279,7 +279,7 @@
         /// <summary>
         /// Renders overlays (node selection, segment selection, etc.)
         /// </summary>
-        /// <param name="cameraInfo"></param>
+        /// <param name="cameraInfo">The camera to use</param>
         public override void RenderOverlay(RenderManager.CameraInfo cameraInfo) {
             // Log._Debug($"RenderOverlay");
             // Log._Debug($"RenderOverlay: {_toolMode} {activeSubTool} {this.GetHashCode()}");

--- a/TLM/TLM/Util/Caching/CameraTransformValue.cs
+++ b/TLM/TLM/Util/Caching/CameraTransformValue.cs
@@ -1,0 +1,37 @@
+namespace TrafficManager.Util.Caching {
+    using UnityEngine;
+    using Util;
+
+    /// <summary>
+    /// Stores transform of the camera, namely position, rotation.
+    /// Fov and other parameters are not stored and not checked.
+    /// Having two inequal transforms means that the camera has moved, or turned.
+    /// </summary>
+    public class CameraTransformValue {
+        private Vector3 Position;
+        private Quaternion Rot;
+
+        public CameraTransformValue() {
+            Position = Vector3.zero;
+            Rot = Quaternion.identity;
+        }
+
+        public CameraTransformValue(Camera cam) {
+            Transform t = cam.transform;
+            Position = t.position;
+            Rot = t.rotation;
+        }
+
+        public override bool Equals(object obj) {
+            // assume this is only ever compared against another CameraTransformValue
+            var other = (CameraTransformValue)obj;
+            return FloatUtil.NearlyEqual(Position.x, other.Position.x)
+                   && FloatUtil.NearlyEqual(Position.y, other.Position.y)
+                   && FloatUtil.NearlyEqual(Position.z, other.Position.z)
+                   && FloatUtil.NearlyEqual(Rot.x, other.Rot.x)
+                   && FloatUtil.NearlyEqual(Rot.y, other.Rot.y)
+                   && FloatUtil.NearlyEqual(Rot.z, other.Rot.z)
+                   && FloatUtil.NearlyEqual(Rot.w, other.Rot.w);
+        }
+    }
+}

--- a/TLM/TLM/Util/Caching/GenericArrayCache.cs
+++ b/TLM/TLM/Util/Caching/GenericArrayCache.cs
@@ -1,0 +1,34 @@
+namespace TrafficManager.Util.Caching {
+    using CSUtil.Commons;
+
+    /// <summary>
+    /// Caches something in an array (of fixed size). The array can be reset.
+    /// <typeparam name="TValue">Type stored in the array</typeparam>
+    /// </summary>
+    public class GenericArrayCache<TValue> {
+        public TValue[] Values;
+        public int Size;
+        private readonly int MaxSize;
+
+        public GenericArrayCache(int size) {
+            MaxSize = size;
+            Values = new TValue[size];
+            Size = 0;
+        }
+
+        public void Add(TValue value) {
+            Log._DebugIf(
+                Size >= MaxSize,
+                     () => $"Adding {value} to GenericArrayCache over the capacity {MaxSize}");
+            Values[Size] = value;
+            Size++;
+        }
+
+        /// <summary>
+        /// Resets the array to begin anew
+        /// </summary>
+        public void Clear() {
+            Size = 0;
+        }
+    }
+}


### PR DESCRIPTION
Closes #520

On my machine and my city saves about 12-25 ms (50-60ms jumps to 75-85 ms) per frame as long as the camera remains stationary.

- [x] Add two new utility classes for storing an array of something (node ids or segment ids) and for storing camera position and rotation
- [x] Use the new functionality in
  - [x] Lane Connector tool
  - [x] Speed Limits tool
  - [x] Parking Restrictions tool

Not used in Priority Signs tool and in Vehicle Restrictions tool because they have own different caching mechanism.