### PR TITLE
[Facelift] Lane Connectors now have contrast outlines

### DIFF
--- a/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
@@ -842,7 +842,7 @@
                 cameraInfo,
                 outlineColor,
                 bezier,
-                size * 2f,
+                size * 1.5f,
                 0,
                 0,
                 -1f,


### PR DESCRIPTION
* Change color palette to distinct color set, and only allocate colors for source lanes (previously both source and target lanes got allocated a color even though target lanes did not need a color).
* Render target lanes as white circles.
* Render black outline around the lane connectors, and black outline around node circles.
* Render white outline and use brighter color of the same hue, while dragging a curve

![image](https://user-images.githubusercontent.com/288724/65377066-bffa1e80-dca7-11e9-9cdb-312c94134ebe.png)

Contributes to #523