### PR TITLE
Bugfix - manual traffic lights tool index out of range

### DIFF
--- a/TLM/TLM/Manager/Impl/ExtSegmentEndManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtSegmentEndManager.cs
@@ -410,11 +410,15 @@
                     continue;
                 }
 
-                var otherStartNode = (bool)Constants.ServiceFactory.NetService
+                var otherStartNode = Constants.ServiceFactory.NetService
                                                     .IsStartNode(otherSegmentId, segEnd.nodeId);
+                if (otherStartNode == null) {
+                    Log.Warning($"Incorrect ExtSegmentEnd.nodeId - data integrity problem! Segment {otherSegmentId} is not connected to Node {segEnd.nodeId}");
+                    continue;
+                }
 
                 ExtSegmentEnd otherSegEnd =
-                    ExtSegmentEnds[GetIndex(otherSegmentId, otherStartNode)];
+                    ExtSegmentEnds[GetIndex(otherSegmentId, (bool)otherStartNode)];
 
                 if (!otherSegEnd.outgoing) {
                     continue;

--- a/TLM/TLM/UI/SubTools/ManualTrafficLightsTool.cs
+++ b/TLM/TLM/UI/SubTools/ManualTrafficLightsTool.cs
@@ -259,7 +259,7 @@
 
                         segEndMan.CalculateOutgoingLeftStraightRightSegments(
                             ref segEnd,
-                            ref nodesBuffer[segmentId],
+                            ref nodesBuffer[SelectedNodeId],
                             out bool hasLeftSegment,
                             out bool hasForwardSegment,
                             out bool hasRightSegment);


### PR DESCRIPTION
Fixed bug in `ManualTrafficLights` tool which prevented from correct rendering of traffic light buttons and threw an `IndexOutOfRangeException`.

Reported by user leonpeonleon on Discord

Side note: bug was there before Harmony merge...
It was hard to spot because of small difference in length of both arrays:
 - `Nodes = 32,768`
 - `Segments = 36,864`