### PR TITLE
IterateNodeSegments sometimes does not work. Fixes #549

### DIFF
--- a/TLM/TMPE.CitiesGameBridge/Service/NetService.cs
+++ b/TLM/TMPE.CitiesGameBridge/Service/NetService.cs
@@ -1,4 +1,4 @@
-﻿namespace CitiesGameBridge.Service {
+namespace CitiesGameBridge.Service {
     using System;
     using System.Collections.Generic;
     using ColossalFramework;
@@ -121,6 +121,12 @@
                     }
                 } else {
                     ushort segmentId = node.GetSegment(0);
+                    for (int i = 0; i < 8; ++i) {
+                        segmentId = node.GetSegment(i);
+                        if (segmentId != 0) {
+                            break;
+                        }
+                    }
                     ushort initSegId = segmentId;
 
                     while (true) {

--- a/TLM/TMPE.CitiesGameBridge/Service/NetService.cs
+++ b/TLM/TMPE.CitiesGameBridge/Service/NetService.cs
@@ -120,7 +120,7 @@ namespace CitiesGameBridge.Service {
                         }
                     }
                 } else {
-                    ushort segmentId = node.GetSegment(0);
+                    ushort segmentId = 0;
                     for (int i = 0; i < 8; ++i) {
                         segmentId = node.GetSegment(i);
                         if (segmentId != 0) {


### PR DESCRIPTION
Fixes #549 . See the issue for full dets.
I tested this and it works. Here is how I tested it:
This bug was breaking my roundabout detection. With this patch my roundabout detection works again.


