### PR TITLE
Null reference OnEnable - hotfix

### DIFF
--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -264,9 +264,11 @@
 
         // Overridden to disable base class behavior
         protected override void OnEnable() {
-            Log._Debug("TrafficManagerTool.OnEnable(): Performing cleanup");
-            foreach (KeyValuePair<ToolMode, SubTool> e in subTools_) {
-                e.Value.Cleanup();
+            if (subTools_ != null) {
+                Log._Debug("TrafficManagerTool.OnEnable(): Performing cleanup");
+                foreach (KeyValuePair<ToolMode, SubTool> e in subTools_) {
+                    e.Value.Cleanup();
+                }
             }
         }
 


### PR DESCRIPTION
Partial fix for #563

I wrapped code inside `if` because `OnEnable` is called automatically(by Unity) every time when tool is going to be enabled. On first call that dictionary of TM:PE subtools does not exist yet