### PR TITLE
Ensure a valid langauge is always used

### DIFF
--- a/TLM/TLM/State/OptionsTabs/OptionsGeneralTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsGeneralTab.cs
@@ -157,11 +157,13 @@ namespace TrafficManager.State {
             if (newLanguageIndex <= 0) {
                 GlobalConfig.Instance.LanguageCode = null;
                 GlobalConfig.WriteConfig();
+                Translation.SetCurrentLanguageToGameLanguage();
                 Options.RebuildMenu();
             } else if (newLanguageIndex - 1 < Translation.AvailableLanguageCodes.Count) {
                 string newLang = Translation.AvailableLanguageCodes[newLanguageIndex - 1];
                 GlobalConfig.Instance.LanguageCode = newLang;
                 GlobalConfig.WriteConfig();
+                Translation.SetCurrentLanguageToTMPELanguage();
                 Options.RebuildMenu();
             } else {
                 Log.Warning($"Options.onLanguageChanged: Invalid language index: {newLanguageIndex}");

--- a/TLM/TLM/TrafficManagerMod.cs
+++ b/TLM/TLM/TrafficManagerMod.cs
@@ -2,11 +2,13 @@ namespace TrafficManager
 {
     using System;
     using System.Reflection;
+    using ColossalFramework.Globalization;
     using ColossalFramework.UI;
     using CSUtil.Commons;
     using ICities;
     using JetBrains.Annotations;
     using State;
+    using TrafficManager.UI;
     using Util;
 
     public class TrafficManagerMod : IUserMod {
@@ -72,10 +74,17 @@ namespace TrafficManager
         public void OnDisabled() {
             Log.Info("TM:PE disabled.");
             LoadingManager.instance.m_introLoaded -= CheckForIncompatibleMods;
+            LocaleManager.eventLocaleChanged -= Translation.SetCurrentLanguageToGameLanguage;
+            Translation.IsListeningToGameLocaleChanged = false; // is this necessary?
         }
 
         [UsedImplicitly]
         public void OnSettingsUI(UIHelperBase helper) {
+            // Note: This bugs out if done in OnEnabled(), hence doing it here instead.
+            if (!Translation.IsListeningToGameLocaleChanged) {
+                Translation.IsListeningToGameLocaleChanged = true;
+                LocaleManager.eventLocaleChanged += new LocaleManager.LocaleChangedHandler(Translation.HandleGameLocaleChange);
+            }
             Options.MakeSettings(helper);
         }
 

--- a/TLM/TLM/TrafficManagerMod.cs
+++ b/TLM/TLM/TrafficManagerMod.cs
@@ -24,7 +24,7 @@ namespace TrafficManager
         public const uint GAME_VERSION_C = 1u;
         public const uint GAME_VERSION_BUILD = 2u;
 
-        public const string VERSION = "11.0-alpha4";
+        public const string VERSION = "11.0-alpha11";
 
         public static readonly string ModName = "TM:PE " + BRANCH + " " + VERSION;
 

--- a/TLM/TLM/TrafficManagerMod.cs
+++ b/TLM/TLM/TrafficManagerMod.cs
@@ -74,7 +74,7 @@ namespace TrafficManager
         public void OnDisabled() {
             Log.Info("TM:PE disabled.");
             LoadingManager.instance.m_introLoaded -= CheckForIncompatibleMods;
-            LocaleManager.eventLocaleChanged -= Translation.SetCurrentLanguageToGameLanguage;
+            LocaleManager.eventLocaleChanged -= Translation.HandleGameLocaleChange;
             Translation.IsListeningToGameLocaleChanged = false; // is this necessary?
         }
 

--- a/TLM/TLM/UI/Localization/Translation.cs
+++ b/TLM/TLM/UI/Localization/Translation.cs
@@ -306,6 +306,11 @@ namespace TrafficManager.UI {
             return CurrentLanguage;
         }
 
+#if DEBUG
+        /// <summary>
+        /// Used to size the in-game debug menu based on chosen langauge.
+        /// </summary>
+        /// <returns>Width to use for the menu.</returns>
         internal static int GetMenuWidth() {
             switch (GetCurrentLanguage()) {
                 // also: case null:
@@ -331,5 +336,6 @@ namespace TrafficManager.UI {
                 }
             }
         }
+#endif
     }
 }

--- a/TLM/TLM/UI/Localization/Translation.cs
+++ b/TLM/TLM/UI/Localization/Translation.cs
@@ -172,8 +172,6 @@ namespace TrafficManager.UI {
         }
 
         private static string GetValidLanguageId(string language) {
-            if (AvailableLanguageCodes.Contains(language))
-                return language;
 
             switch (language) {
                 case "jaex": {
@@ -190,10 +188,10 @@ namespace TrafficManager.UI {
                     language = "ko";
                     break;
                 }
+            }
 
-                default:
-                    language = "en";
-                    break;
+            if (!AvailableLanguageCodes.Contains(language)) {
+                language = DEFAULT_LANGUAGE_CODE;
             }
 
             return language;

--- a/TLM/TLM/UI/Localization/Translation.cs
+++ b/TLM/TLM/UI/Localization/Translation.cs
@@ -89,7 +89,7 @@ namespace TrafficManager.UI {
             LoadingExtension.TranslationDatabase.aiCarLookup_;
 
         /// <summary>
-        /// Gets or sets a value indicating whether indicates whether we've checked the validity of language code at least once
+        /// Gets or sets a value indicating whether we've checked the validity of language code at least once
         /// <see cref="GetCurrentLanguage"/>.
         /// </summary>
         internal static bool IsLanguageCodeVerified { get; set; } = false;


### PR DESCRIPTION
This fixes an issue where user might select a new language, then revert to older version of mod that doesn't have that language; it would try using the previously selected language, not find it, and crash.

![image](https://user-images.githubusercontent.com/1386719/69845990-75c68800-126a-11ea-8a30-10734e829606.png)

This PR ensures default language will be used in any case where selected language is not available.

Note, however, this will obviously only fix the issue from version 11.0-alpha11 and above. There is no way to retroactively fix it on older versions of the mod.