### PR TITLE
Disambiguate `LeftHandDrive` to `TrafficDrivesOnLeft`

### DIFF
--- a/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
@@ -401,11 +401,11 @@ namespace TrafficManager.Manager.Impl {
                                                    ref NetNode node) {
             ITurnOnRedManager turnOnRedMan = Constants.ManagerFactory.TurnOnRedManager;
             int index = turnOnRedMan.GetIndex(segmentId, startNode);
-            bool lhd = Services.SimulationService.LeftHandDrive;
+            bool lht = Services.SimulationService.TrafficDrivesOnLeft;
             bool ret =
                 (node.m_flags & NetNode.Flags.TrafficLights) != NetNode.Flags.None &&
-                (((lhd == near) && turnOnRedMan.TurnOnRedSegments[index].leftSegmentId != 0) ||
-                 ((!lhd == near) && turnOnRedMan.TurnOnRedSegments[index].rightSegmentId != 0));
+                (((lht == near) && turnOnRedMan.TurnOnRedSegments[index].leftSegmentId != 0) ||
+                ((!lht == near) && turnOnRedMan.TurnOnRedSegments[index].rightSegmentId != 0));
 #if DEBUG
             if (DebugSwitch.JunctionRestrictions.Get()) {
                 Log._Debug(

--- a/TLM/TLM/Manager/Impl/LaneArrowManager.cs
+++ b/TLM/TLM/Manager/Impl/LaneArrowManager.cs
@@ -340,7 +340,7 @@ namespace TrafficManager.Manager.Impl {
                             DistributeLanes2(srcLaneCount, leftLanesCount, rightLanesCount, out l, out r);
                         }
                     } else {
-                        //if traffic drives on right, then favour the more difficult right turns.
+                        //if traffic drives on left, then favour the more difficult right turns.
                         if (leftLanesCount == 0) {
                             DistributeLanes2(srcLaneCount, rightLanesCount, forwardLanesCount, out r, out f);
                         } else if (rightLanesCount == 0) {

--- a/TLM/TLM/Manager/Impl/LaneArrowManager.cs
+++ b/TLM/TLM/Manager/Impl/LaneArrowManager.cs
@@ -327,10 +327,10 @@ namespace TrafficManager.Manager.Impl {
                 }
 
                 int l = 0, f = 0, r = 0;
-                bool lhd = LaneArrowManager.Instance.Services.SimulationService.LeftHandDrive;
+                bool lht = LaneArrowManager.Instance.Services.SimulationService.TrafficDrivesOnLeft;
                 if (numdirs == 2) {
-                    if (!lhd) {
-                        //if right hand drive then favour the more difficult left turns.
+                    if (!lht) {
+                        //if traffic drives on right, then favour the more difficult left turns.
                         if (leftLanesCount == 0) {
                             DistributeLanes2(srcLaneCount, forwardLanesCount, rightLanesCount, out f, out r);
                         } else if (rightLanesCount == 0) {
@@ -340,7 +340,7 @@ namespace TrafficManager.Manager.Impl {
                             DistributeLanes2(srcLaneCount, leftLanesCount, rightLanesCount, out l, out r);
                         }
                     } else {
-                        //if left hand drive then favour the more difficult right turns.
+                        //if traffic drives on right, then favour the more difficult right turns.
                         if (leftLanesCount == 0) {
                             DistributeLanes2(srcLaneCount, rightLanesCount, forwardLanesCount, out r, out f);
                         } else if (rightLanesCount == 0) {
@@ -352,7 +352,7 @@ namespace TrafficManager.Manager.Impl {
                     }
                 } else {
                     Debug.Assert(numdirs == 3 && srcLaneCount >= 3);
-                    if (!lhd) {
+                    if (!lht) {
                         DistributeLanes3(srcLaneCount, leftLanesCount, forwardLanesCount, rightLanesCount, out l, out f, out r);
                     } else {
                         DistributeLanes3(srcLaneCount, rightLanesCount, forwardLanesCount, leftLanesCount, out r, out f, out l);

--- a/TLM/TLM/Manager/Impl/LaneConnectionManager.cs
+++ b/TLM/TLM/Manager/Impl/LaneConnectionManager.cs
@@ -654,7 +654,7 @@ namespace TrafficManager.Manager.Impl {
                     // check if arrow has already been set for this direction
                     switch (dir) {
                         case ArrowDirection.Turn: {
-                            if (Constants.ServiceFactory.SimulationService.LeftHandDrive) {
+                            if (Constants.ServiceFactory.SimulationService.TrafficDrivesOnLeft) {
                                 if ((arrows & LaneArrows.Right) != LaneArrows.None) {
                                     return true;
                                 }
@@ -740,7 +740,7 @@ namespace TrafficManager.Manager.Impl {
 
                     switch (dir) {
                         case ArrowDirection.Turn: {
-                            if (Constants.ServiceFactory.SimulationService.LeftHandDrive) {
+                            if (Constants.ServiceFactory.SimulationService.TrafficDrivesOnLeft) {
                                 arrows |= LaneArrows.Right;
                             } else {
                                 arrows |= LaneArrows.Left;

--- a/TLM/TLM/Manager/Impl/RoutingManager.cs
+++ b/TLM/TLM/Manager/Impl/RoutingManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.Manager.Impl {
+namespace TrafficManager.Manager.Impl {
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -419,7 +419,7 @@
                     return true;
                 });
 
-            bool leftHandDrive = Constants.ServiceFactory.SimulationService.LeftHandDrive;
+            bool lht = Constants.ServiceFactory.SimulationService.TrafficDrivesOnLeft;
 
             IExtSegmentEndManager segEndMan = Constants.ManagerFactory.ExtSegmentEndManager;
             ExtSegment prevSeg = Constants.ManagerFactory.ExtSegmentManager.ExtSegments[segmentId];
@@ -549,7 +549,7 @@
                 Log._DebugFormat(
                     "RoutingManager.RecalculateLaneEndRoutingData({0}, {1}, {2}, {3}): " +
                     "prevSegIsInverted={4} leftHandDrive={5}",
-                    segmentId, laneIndex, laneId, startNode, prevSegIsInverted, leftHandDrive);
+                    segmentId, laneIndex, laneId, startNode, prevSegIsInverted, lht);
                 Log._DebugFormat(
                     "RoutingManager.RecalculateLaneEndRoutingData({0}, {1}, {2}, {3}): " +
                     "prevSimilarLaneCount={4} prevInnerSimilarLaneIndex={5} prevOuterSimilarLaneIndex={6} " +
@@ -870,8 +870,8 @@
                                         (nextIncomingDir == ArrowDirection.Turn
                                          && (!nextIsRealJunction
                                              || nextIsEndOrOneWayOut
-                                             || ((leftHandDrive && hasRightArrow)
-                                                 || (!leftHandDrive && hasLeftArrow))))) // valid turning lane
+                                             || ((lht && hasRightArrow)
+                                                 || (!lht && hasLeftArrow))))) // valid turning lane
                                     {
                                         if (extendedLogRouting) {
                                             Log._DebugFormat(
@@ -1920,7 +1920,7 @@
                     Constants.ServiceFactory.NetService.ProcessSegment(
                         nextSegmentId,
                         (ushort nextSegId, ref NetSegment segment) => {
-                            nextSegmentId = Constants.ServiceFactory.SimulationService.LeftHandDrive
+                            nextSegmentId = Constants.ServiceFactory.SimulationService.TrafficDrivesOnLeft
                                                 ? segment.GetLeftSegment(nextNodeId)
                                                 : segment.GetRightSegment(nextNodeId);
                             return true;

--- a/TLM/TLM/Manager/Impl/TrafficPriorityManager.cs
+++ b/TLM/TLM/Manager/Impl/TrafficPriorityManager.cs
@@ -900,15 +900,15 @@ namespace TrafficManager.Manager.Impl {
                     vehicleId, incomingVehicleId, targetToDir, incomingFromDir, incomingToRelDir);
             }
 
-            if (Services.SimulationService.LeftHandDrive) {
-                // mirror situation for left-hand traffic systems
+            if (Services.SimulationService.TrafficDrivesOnLeft) {
+                // mirror situation if traffic drives on left
                 targetToDir = ArrowDirectionUtil.InvertLeftRight(targetToDir);
                 incomingFromDir = ArrowDirectionUtil.InvertLeftRight(incomingFromDir);
                 incomingToRelDir = ArrowDirectionUtil.InvertLeftRight(incomingToRelDir);
 
                 if (logPriority) {
                     Log._DebugFormat(
-                        "  TrafficPriorityManager.HasVehiclePriority({0}, {1}): LHD! targetToDir: {2}, " +
+                        "  TrafficPriorityManager.HasVehiclePriority({0}, {1}): LHT! targetToDir: {2}, " +
                         "incomingFromDir: {3}, incomingToRelDir: {4}",
                         vehicleId, incomingVehicleId, targetToDir, incomingFromDir, incomingToRelDir);
                 }
@@ -1366,7 +1366,7 @@ namespace TrafficManager.Manager.Impl {
                       NetSegment.Flags.Invert) == NetSegment.Flags.None)
                         ? dir
                         : NetInfo.InvertDirection(dir);
-                NetInfo.Direction dir3 = Services.SimulationService.LeftHandDrive
+                NetInfo.Direction dir3 = Services.SimulationService.TrafficDrivesOnLeft
                                              ? NetInfo.InvertDirection(dir2)
                                              : dir2;
 

--- a/TLM/TLM/Manager/Impl/TurnOnRedManager.cs
+++ b/TLM/TLM/Manager/Impl/TurnOnRedManager.cs
@@ -129,7 +129,7 @@ namespace TrafficManager.Manager.Impl {
                 return;
             }
 
-            bool lhd = Services.SimulationService.LeftHandDrive;
+            bool lht = Services.SimulationService.TrafficDrivesOnLeft;
 
             // check node
             // note that we must not check for the `TrafficLights` flag here because the flag might not be loaded yet
@@ -219,7 +219,7 @@ namespace TrafficManager.Manager.Impl {
             }
 
             if (seg.oneWay) {
-                if ((lhd && rightSegmentId != 0) || (!lhd && leftSegmentId != 0)) {
+                if ((lht && rightSegmentId != 0) || (!lht && leftSegmentId != 0)) {
                     // special case: one-way to one-way in non-preferred direction
                     if (logTurnOnRed) {
                         Log._Debug(
@@ -227,24 +227,24 @@ namespace TrafficManager.Manager.Impl {
                             "source is incoming one-way. checking for one-way in non-preferred direction");
                     }
 
-                    ushort targetSegmentId = lhd ? rightSegmentId : leftSegmentId;
+                    ushort targetSegmentId = lht ? rightSegmentId : leftSegmentId;
 
                     if (!segmentManager.ExtSegments[targetSegmentId].oneWay) {
                         // disallow turn in non-preferred direction
                         if (logTurnOnRed) {
                             Log._Debug(
                                 $"TurnOnRedManager.UpdateSegmentEnd({end.segmentId}, {end.startNode}): " +
-                                $"turn in non-preferred direction {(lhd ? "right" : "left")} disallowed");
+                                $"turn in non-preferred direction {(lht ? "right" : "left")} disallowed");
                         }
 
-                        if (lhd) {
+                        if (lht) {
                             rightSegmentId = 0;
                         } else {
                             leftSegmentId = 0;
                         }
                     }
                 }
-            } else if (lhd) {
+            } else if (lht) {
                 // default case (LHD): turn in preferred direction
                 rightSegmentId = 0;
             } else {

--- a/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
+++ b/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.Manager.Impl {
+namespace TrafficManager.Manager.Impl {
     using System;
     using API.Manager;
     using API.Traffic.Data;
@@ -1393,19 +1393,19 @@
                         IJunctionRestrictionsManager junctionRestrictionsManager
                             = Constants.ManagerFactory.JunctionRestrictionsManager;
                         ITurnOnRedManager turnOnRedMan = Constants.ManagerFactory.TurnOnRedManager;
-                        bool lhd = Constants.ServiceFactory.SimulationService.LeftHandDrive;
+                        bool lht = Constants.ServiceFactory.SimulationService.TrafficDrivesOnLeft;
                         int torIndex = turnOnRedMan.GetIndex(prevPos.m_segment, isTargetStartNode);
 
                         if ((turnOnRedMan.TurnOnRedSegments[torIndex].leftSegmentId ==
                              position.m_segment
                              && junctionRestrictionsManager.IsTurnOnRedAllowed(
-                                 lhd,
+                                 lht,
                                  prevPos.m_segment,
                                  isTargetStartNode))
                             || (turnOnRedMan.TurnOnRedSegments[torIndex].rightSegmentId ==
                                 position.m_segment
                                 && junctionRestrictionsManager.IsTurnOnRedAllowed(
-                                    !lhd,
+                                    !lht,
                                     prevPos.m_segment,
                                     isTargetStartNode)))
                         {

--- a/TLM/TLM/TrafficLight/Impl/CustomSegmentLight.cs
+++ b/TLM/TLM/TrafficLight/Impl/CustomSegmentLight.cs
@@ -1,4 +1,4 @@
-﻿// #define DEBUGVISUALS
+// #define DEBUGVISUALS
 
 namespace TrafficManager.TrafficLight.Impl {
     using System;
@@ -262,7 +262,7 @@ namespace TrafficManager.TrafficLight.Impl {
                 }
 
                 case ArrowDirection.Turn: {
-                    return Constants.ServiceFactory.SimulationService.LeftHandDrive
+                    return Constants.ServiceFactory.SimulationService.TrafficDrivesOnLeft
                                ? LightRight
                                : LightLeft;
                 }

--- a/TLM/TLM/TrafficLight/Impl/CustomSegmentLights.cs
+++ b/TLM/TLM/TrafficLight/Impl/CustomSegmentLights.cs
@@ -1,4 +1,4 @@
-﻿// #define DEBUGGET
+// #define DEBUGGET
 
 namespace TrafficManager.TrafficLight.Impl {
     using System;
@@ -493,7 +493,7 @@ namespace TrafficManager.TrafficLight.Impl {
                 });
 
             var autoPedestrianLightState = RoadBaseAI.TrafficLightState.Green;
-            bool lhd = Constants.ServiceFactory.SimulationService.LeftHandDrive;
+            bool lht = Constants.ServiceFactory.SimulationService.TrafficDrivesOnLeft;
 
             if (!(segEnd.incoming && seg.oneWay)) {
                 for (int i = 0; i < 8; ++i) {
@@ -561,10 +561,10 @@ namespace TrafficManager.TrafficLight.Impl {
                             autoPedestrianLightState = RoadBaseAI.TrafficLightState.Red;
                             break;
                         }
-                    } else if (((dir == ArrowDirection.Left && lhd)
-                                || (dir == ArrowDirection.Right && !lhd))
-                               && ((lhd && !otherLights.IsAllRightRed())
-                                   || (!lhd && !otherLights.IsAllLeftRed())))
+                    } else if (((dir == ArrowDirection.Left && lht)
+                                || (dir == ArrowDirection.Right && !lht))
+                               && ((lht && !otherLights.IsAllRightRed())
+                                   || (!lht && !otherLights.IsAllLeftRed())))
                     {
                         Log._DebugIf(
                             logTrafficLights,

--- a/TLM/TLM/TrafficLight/Impl/TimedTrafficLightsStep.cs
+++ b/TLM/TLM/TrafficLight/Impl/TimedTrafficLightsStep.cs
@@ -925,7 +925,7 @@ namespace TrafficManager.TrafficLight.Impl {
                             switch (dir) {
                                 case ArrowDirection.Turn: {
                                     addToFlow =
-                                        Constants.ServiceFactory.SimulationService.LeftHandDrive
+                                        Constants.ServiceFactory.SimulationService.TrafficDrivesOnLeft
                                             ? segLight.IsRightGreen()
                                             : segLight.IsLeftGreen();
                                     break;

--- a/TLM/TLM/UI/SubTools/JunctionRestrictionsTool.cs
+++ b/TLM/TLM/UI/SubTools/JunctionRestrictionsTool.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.UI.SubTools {
+namespace TrafficManager.UI.SubTools {
     using System.Collections.Generic;
     using API.Manager;
     using ColossalFramework;
@@ -241,7 +241,7 @@
                 Vector3 centerStart = nodePos + (yu * (viewOnly ? 5f : 14f));
                 Vector3 zero = centerStart - (0.5f * (numSignsPerRow-1) * f * xu); // "top left"
                 if (viewOnly) {
-                    if (Constants.ServiceFactory.SimulationService.LeftHandDrive) {
+                    if (Constants.ServiceFactory.SimulationService.TrafficDrivesOnLeft) {
                         zero -= xu * 8f;
                     } else {
                         zero += xu * 8f;
@@ -475,12 +475,12 @@
                 //--------------------------------
                 IJunctionRestrictionsManager junctionRestrictionsManager =
                     Constants.ManagerFactory.JunctionRestrictionsManager;
-                bool lhd = Constants.ServiceFactory.SimulationService.LeftHandDrive;
+                bool lht = Constants.ServiceFactory.SimulationService.TrafficDrivesOnLeft;
 
                 // draw "turn-left-on-red allowed" sign at (2; 0)
-                allowed = junctionRestrictionsManager.IsTurnOnRedAllowed(lhd, segmentId, startNode);
+                allowed = junctionRestrictionsManager.IsTurnOnRedAllowed(lht, segmentId, startNode);
                 configurable = junctionRestrictionsManager.IsTurnOnRedAllowedConfigurable(
-                    lhd,
+                    lht,
                     segmentId,
                     startNode,
                     ref node);
@@ -490,7 +490,7 @@
                         && (!viewOnly
                             || (allowed != junctionRestrictionsManager
                                     .GetDefaultTurnOnRedAllowed(
-                                        lhd,
+                                        lht,
                                         segmentId,
                                         startNode,
                                         ref node)))))
@@ -516,7 +516,7 @@
 
                         if (MainTool.CheckClicked()) {
                             junctionRestrictionsManager.ToggleTurnOnRedAllowed(
-                                lhd,
+                                lht,
                                 segmentId,
                                 startNode);
                             stateUpdated = true;
@@ -530,11 +530,11 @@
 
                 // draw "turn-right-on-red allowed" sign at (2; 1)
                 allowed = junctionRestrictionsManager.IsTurnOnRedAllowed(
-                    !lhd,
+                    !lht,
                     segmentId,
                     startNode);
                 configurable = junctionRestrictionsManager.IsTurnOnRedAllowedConfigurable(
-                    !lhd,
+                    !lht,
                     segmentId,
                     startNode,
                     ref node);
@@ -544,7 +544,7 @@
                         && (!viewOnly
                             || (allowed != junctionRestrictionsManager
                                     .GetDefaultTurnOnRedAllowed(
-                                        !lhd,
+                                        !lht,
                                         segmentId,
                                         startNode,
                                         ref node)))))
@@ -570,7 +570,7 @@
 
                         if (MainTool.CheckClicked()) {
                             junctionRestrictionsManager.ToggleTurnOnRedAllowed(
-                                !lhd,
+                                !lht,
                                 segmentId,
                                 startNode);
                             stateUpdated = true;

--- a/TLM/TMPE.CitiesGameBridge/Service/SimulationService.cs
+++ b/TLM/TMPE.CitiesGameBridge/Service/SimulationService.cs
@@ -1,4 +1,4 @@
-﻿namespace CitiesGameBridge.Service {
+namespace CitiesGameBridge.Service {
     using System;
     using ColossalFramework;
     using ColossalFramework.Math;
@@ -10,9 +10,13 @@
 
         private SimulationService() { }
 
-        public bool LeftHandDrive =>
+        public bool TrafficDrivesOnLeft =>
             Singleton<SimulationManager>.instance.m_metaData.m_invertTraffic
             == SimulationMetaData.MetaBool.True;
+
+        [Obsolete]
+        public bool LeftHandDrive =>
+            TrafficDrivesOnLeft;
 
         public uint CurrentBuildIndex {
             get => Singleton<SimulationManager>.instance.m_currentBuildIndex;

--- a/TLM/TMPE.GenericGameBridge/Service/ISimulationService.cs
+++ b/TLM/TMPE.GenericGameBridge/Service/ISimulationService.cs
@@ -1,9 +1,13 @@
-﻿namespace GenericGameBridge.Service {
+namespace GenericGameBridge.Service {
     using ColossalFramework.Math;
+    using System;
     using UnityEngine;
 
     public interface ISimulationService {
+        [Obsolete]
         bool LeftHandDrive { get; }
+
+        bool TrafficDrivesOnLeft { get; }
 
         uint CurrentBuildIndex { get; set; }
 


### PR DESCRIPTION
Fixes #577 - h/t @kianzarrin for reporting the issue

The term "LHD" (Left Hand Drive_r_) actually relates to traffic driving on _the right_ (RHT, or Right Hand Traffic). However, TM:PE was regularly using the term to refer to the situation where traffic drives on the left (which is actually RHD / LHT).

To avoid ongoing mass confusion, this PR obsoletes `Services.SimulationService.LeftHandDrive` and adds a new disambiguous `Services.SimulationService.TrafficDrivesOnLeft`.

Uses of the obsolete property have been updated to use the new property. Also any instances of that code creating variables called `lhd` (ie. traffic drives on right) have been updated to `lht` (left hand traffic, which would be right hand driver).

Features affected include:

* Junction restrictions (particularly "Turn on Red")
* Lane arrows
* Lane connectors
* Priority signs
* Timed Traffic Lights
* Also, `RoutingManager` was updated, so anything that affects.

Everything should just work, as all that's changed is the property name, not it's value.

Side note: As far as I can tell, all uses of the now-obsolete `LeftHandDrive` property are updated to use `TrafficDrivesOnLeft` - should the obsolete property be removed?