### PR TITLE
Added a readme to translations folder

### DIFF
--- a/TLM/TLM/Resources/Translations/README.md
+++ b/TLM/TLM/Resources/Translations/README.md
@@ -1,0 +1,7 @@
+## Contributing Translations
+
+Please don't edit these files directly; we use a web service to maintain the translations.
+
+For more information, see: [Localisation Guide for Translators](https://github.com/krzychu124/Cities-Skylines-Traffic-Manager-President-Edition/wiki/Localisation).
+
+If you need any additional information or assistance, please [create a Translation Issue ticket](https://github.com/krzychu124/Cities-Skylines-Traffic-Manager-President-Edition/issues/new?labels=Localisation%2C+triage&template=translation-update.md) or contact us via [Discord Chat](https://discord.gg/faKUnST).


### PR DESCRIPTION
Noticed that a few people had sent PRs with manually updated translations over the past few months, so added a `README.md` to the `TLM/Resources/Translations` folder which indicates that translations should be done via Crowdin.