### PR TITLE
Bugfix - remove Timed Traffic Lights from group

### DIFF
--- a/TLM/TLM/Manager/Impl/TrafficLightSimulationManager.cs
+++ b/TLM/TLM/Manager/Impl/TrafficLightSimulationManager.cs
@@ -11,7 +11,6 @@ namespace TrafficManager.Manager.Impl {
     using State;
     using State.ConfigData;
     using Traffic;
-    using TrafficLight;
     using TrafficLight.Impl;
     using static RoadBaseAI;
     using ExtVehicleType = global::TrafficManager.Traffic.ExtVehicleType;
@@ -360,7 +359,7 @@ namespace TrafficManager.Manager.Impl {
                                 });
                         }
                     } else {
-                        if (TrafficLightSimulations[nodeId].IsTimedLight()) {
+                        if (TrafficLightSimulations[timedNodeId].IsTimedLight()) {
                             TrafficLightSimulations[timedNodeId].timedLight.RemoveNodeFromGroup(nodeId);
                         }
                     }

--- a/TLM/TLM/UI/SubTools/TimedTrafficLightsTool.cs
+++ b/TLM/TLM/UI/SubTools/TimedTrafficLightsTool.cs
@@ -236,7 +236,7 @@ namespace TrafficManager.UI.SubTools {
                                             .instance.m_nodes.m_buffer[nodeIdToCopy]
                                             .CountSegments();
                     int numTargetSegments = Singleton<NetManager>
-                                            .instance.m_nodes.m_buffer[nodeIdToCopy]
+                                            .instance.m_nodes.m_buffer[HoveredNodeId]
                                             .CountSegments();
 
                     if (numSourceSegments != numTargetSegments) {


### PR DESCRIPTION

- fixed bug with removing `Timed Traffic Lights` node from `Traffic Light` simulation group, (thanks  @leaderofthemonkeys for reporting this issue) 
- fixed detection of compatible `Timed Traffic Lights` node for copying `Traffic Light` setup