### PR TITLE
Add additional check if hovered node and segments are connected,

### DIFF
--- a/TLM/TLM/UI/SubTools/LaneArrowTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneArrowTool.cs
@@ -128,6 +128,13 @@ namespace TrafficManager.UI.SubTools {
             }
 #endif
             ExtSegmentEndManager segEndMan = ExtSegmentEndManager.Instance;
+            int segmentEndId = segEndMan.GetIndex(segmentId, nodeId);
+            if (segmentEndId <0) {
+#if DEBUG
+                Debug.LogError($"Node {nodeId} is not connected to segment {segmentId}");
+#endif
+                return false;
+            }
             ExtSegmentEnd segEnd = segEndMan.ExtSegmentEnds[segEndMan.GetIndex(segmentId, nodeId)];
             NetNode[] nodesBuffer = Singleton<NetManager>.instance.m_nodes.m_buffer;
             bool bJunction = (nodesBuffer[nodeId].m_flags & NetNode.Flags.Junction) != 0;

--- a/TLM/TLM/UI/SubTools/LaneArrowTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneArrowTool.cs
@@ -130,9 +130,7 @@ namespace TrafficManager.UI.SubTools {
             ExtSegmentEndManager segEndMan = ExtSegmentEndManager.Instance;
             int segmentEndId = segEndMan.GetIndex(segmentId, nodeId);
             if (segmentEndId <0) {
-#if DEBUG
-                Debug.LogError($"Node {nodeId} is not connected to segment {segmentId}");
-#endif
+                Log._Debug($"Node {nodeId} is not connected to segment {segmentId}");
                 return false;
             }
             ExtSegmentEnd segEnd = segEndMan.ExtSegmentEnds[segEndMan.GetIndex(segmentId, nodeId)];

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -27,6 +27,7 @@ namespace TrafficManager.UI {
           IObserver<GlobalConfig>
     {
         private ToolMode toolMode_;
+        private NetTool _netTool;
 
         internal static ushort HoveredNodeId;
         internal static ushort HoveredSegmentId;
@@ -127,6 +128,17 @@ namespace TrafficManager.UI {
             }
 
             return TransparencyToAlpha(transparency);
+        }
+
+        internal NetTool NetTool {
+            get {
+                if (_netTool == null) {
+                    Log._Debug("NetTool field value is null. Searching for instance...");
+                    _netTool = ToolsModifierControl.toolController.Tools.OfType<NetTool>().FirstOrDefault();
+                }
+
+                return _netTool;
+            }
         }
 
         private static float TransparencyToAlpha(byte transparency) {
@@ -322,6 +334,11 @@ namespace TrafficManager.UI {
                     InfoManager.InfoMode.None,
                     InfoManager.SubInfoMode.Default);
             }
+            ToolCursor = null;
+            bool elementsHovered = DetermineHoveredElements();
+            if (_activeSubTool != null && NetTool != null && elementsHovered) {
+                ToolCursor = NetTool.m_upgradeCursor;
+            }
 
             bool primaryMouseClicked = Input.GetMouseButtonDown(0);
             bool secondaryMouseClicked = Input.GetMouseButtonDown(1);
@@ -357,7 +374,6 @@ namespace TrafficManager.UI {
             // }
 
             if (_activeSubTool != null) {
-                DetermineHoveredElements();
 
                 if (primaryMouseClicked) {
                     _activeSubTool.OnPrimaryClickOverlay();
@@ -799,20 +815,6 @@ namespace TrafficManager.UI {
             //                tooltipWorldPos = null;
             //        }
             // }
-
-            if (GetToolMode() == ToolMode.None) {
-                ToolCursor = null;
-            } else {
-                bool elementsHovered = DetermineHoveredElements();
-
-                NetTool netTool = ToolsModifierControl
-                                  .toolController.Tools.OfType<NetTool>()
-                                  .FirstOrDefault(nt => nt.m_prefab != null);
-
-                if (netTool != null && elementsHovered) {
-                    ToolCursor = netTool.m_upgradeCursor;
-                }
-            }
         }
 
         public bool DoRayCast(RaycastInput input, out RaycastOutput output) {


### PR DESCRIPTION
Fixes #606 

- added additional check to be sure that hovered node and segment are connected when testing if segment has arrows,
- fixed cursor flickering when tool is selected (caused by updates from simulation thread)