### PR TITLE
better segment hovering when mouse is on node

### DIFF
--- a/TLM/TLM/UI/SubTools/LaneArrowTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneArrowTool.cs
@@ -143,6 +143,11 @@ namespace TrafficManager.UI.SubTools {
 
         protected override ushort HoveredNodeId {
         get {
+                bool ctrlDown = Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl);
+                if (ctrlDown) {
+                    // When control is down, we are selecting node.
+                    return base.HoveredNodeId;
+                }
                 // if the current segment end does not have lane arrows
                 // and the other end of the segment does have lane arrows, then
                 // assume the user intends to hover over that one.

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -954,7 +954,7 @@ namespace TrafficManager.UI {
             bool considerSegmentLenght = true;
             ushort minSegId = 0;
             NetNode node = NetManager.instance.m_nodes.m_buffer[HoveredNodeId];
-            Vector3 dir0 = node.m_position - m_mousePosition;
+            Vector3 dir0 = m_mousePosition - node.m_position;
             float min_angle = float.MaxValue;
             Constants.ServiceFactory.NetService.IterateNodeSegments(
                 HoveredNodeId,
@@ -963,7 +963,7 @@ namespace TrafficManager.UI {
                     Vector3 dir = segment.m_startNode == HoveredNodeId ?
                         segment.m_startDirection :
                         segment.m_endDirection;
-                    float angle = GetAgnele(-dir, dir0);
+                    float angle = GetAgnele(dir, dir0);
                     if (considerSegmentLenght) {
                         angle *= segment.m_averageLength;
                     }

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -34,8 +34,9 @@ namespace TrafficManager.UI {
 
         private static bool _mouseClickProcessed;
 
-        public const float DEBUG_CLOSE_LOD = 300f;
+        private const bool HoverPrefersSmallerSegments = true;
 
+        public const float DEBUG_CLOSE_LOD = 300f;
         /// <summary>
         /// Square of the distance, where overlays are not rendered
         /// </summary>
@@ -951,7 +952,6 @@ namespace TrafficManager.UI {
         /// returns the node segment that is closest to the mouse pointer based on angle.
         /// </summary>
         internal ushort GetHoveredSegmentFromNode() {
-            bool considerSegmentLenght = true;
             ushort minSegId = 0;
             NetNode node = NetManager.instance.m_nodes.m_buffer[HoveredNodeId];
             Vector3 dir0 = m_mousePosition - node.m_position;
@@ -963,8 +963,8 @@ namespace TrafficManager.UI {
                     Vector3 dir = segment.m_startNode == HoveredNodeId ?
                         segment.m_startDirection :
                         segment.m_endDirection;
-                    float angle = GetAgnele(dir, dir0);
-                    if (considerSegmentLenght) {
+                    float angle = GetAngle(dir, dir0);
+                    if (HoverPrefersSmallerSegments) {
                         angle *= segment.m_averageLength;
                     }
                     if (angle < min_angle) {
@@ -981,7 +981,7 @@ namespace TrafficManager.UI {
         /// input order does not matter.
         /// The return value is between 0 to 180.
         /// </summary>
-        private static float GetAgnele(Vector3 v1, Vector3 v2) {
+        private static float GetAngle(Vector3 v1, Vector3 v2) {
             float ret = Vector3.Angle(v1, v2); // -180 to 180 degree
             if (ret > 180) ret -= 180; // future proofing.
             ret = Math.Abs(ret);


### PR DESCRIPTION
fixes #538
I have explained the math behind my approach in https://github.com/krzychu124/Cities-Skylines-Traffic-Manager-President-Edition/issues/576#issuecomment-559347611 . Please read it.
as suggested by @aubergine10 in https://github.com/krzychu124/Cities-Skylines-Traffic-Manager-President-Edition/issues/576#issuecomment-559659866 I provided option to "buff the clickability of segments based on their length". The option can be configured at compile time.

fixes #594
To fix this: when mouse ray is not valid I set `HoveredSegmentId` and `HoveredSegmentId` to zero

EDIT: fixes #616
I added an exception for when control key is down.