### PR TITLE
Replaced imports with fully qualified imports and sorted alphabetically

### DIFF
--- a/TLM/TLM/Constants.cs
+++ b/TLM/TLM/Constants.cs
@@ -1,7 +1,7 @@
 ﻿namespace TrafficManager {
-    using API.Manager;
     using GenericGameBridge.Factory;
     using JetBrains.Annotations;
+    using TrafficManager.API.Manager;
 
     public static class Constants {
         /// <summary>

--- a/TLM/TLM/Custom/AI/CustomAmbulanceAI.cs
+++ b/TLM/TLM/Custom/AI/CustomAmbulanceAI.cs
@@ -1,11 +1,11 @@
 ﻿namespace TrafficManager.Custom.AI {
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
     using ColossalFramework;
     using JetBrains.Annotations;
-    using Manager.Impl;
-    using PathFinding;
-    using RedirectionFramework.Attributes;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Custom.PathFinding;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.RedirectionFramework.Attributes;
     using UnityEngine;
 
     [TargetType(typeof(AmbulanceAI))]

--- a/TLM/TLM/Custom/AI/CustomBuildingAI.cs
+++ b/TLM/TLM/Custom/AI/CustomBuildingAI.cs
@@ -1,10 +1,10 @@
 ﻿namespace TrafficManager.Custom.AI {
-    using ColossalFramework;
     using ColossalFramework.Math;
+    using ColossalFramework;
     using JetBrains.Annotations;
-    using Manager.Impl;
-    using RedirectionFramework.Attributes;
-    using State;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.RedirectionFramework.Attributes;
+    using TrafficManager.State;
     using UnityEngine;
 
     [TargetType(typeof(BuildingAI))]

--- a/TLM/TLM/Custom/AI/CustomBusAI.cs
+++ b/TLM/TLM/Custom/AI/CustomBusAI.cs
@@ -1,10 +1,10 @@
 ﻿namespace TrafficManager.Custom.AI {
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
     using ColossalFramework;
     using JetBrains.Annotations;
-    using PathFinding;
-    using RedirectionFramework.Attributes;
+    using TrafficManager.Custom.PathFinding;
+    using TrafficManager.RedirectionFramework.Attributes;
     using UnityEngine;
 
     [TargetType(typeof(BusAI))]

--- a/TLM/TLM/Custom/AI/CustomCarAI.cs
+++ b/TLM/TLM/Custom/AI/CustomCarAI.cs
@@ -1,24 +1,24 @@
 // #define DEBUGV
 
 namespace TrafficManager.Custom.AI {
-    using System;
-    using System.Runtime.CompilerServices;
-    using API.Manager;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
-    using ColossalFramework;
     using ColossalFramework.Math;
+    using ColossalFramework;
+    using CSUtil.Commons.Benchmark;
     using CSUtil.Commons;
     using JetBrains.Annotations;
-    using Manager;
-    using Manager.Impl;
-    using PathFinding;
-    using RedirectionFramework.Attributes;
-    using State;
-    using State.ConfigData;
-    using UnityEngine;
     using System.Diagnostics.CodeAnalysis;
-    using CSUtil.Commons.Benchmark;
+    using System.Runtime.CompilerServices;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Custom.PathFinding;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.Manager;
+    using TrafficManager.RedirectionFramework.Attributes;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.State;
+    using UnityEngine;
 
     // TODO inherit from VehicleAI (in order to keep the correct references to `base`)
     [TargetType(typeof(CarAI))]

--- a/TLM/TLM/Custom/AI/CustomCargoTruckAI.cs
+++ b/TLM/TLM/Custom/AI/CustomCargoTruckAI.cs
@@ -1,13 +1,13 @@
 namespace TrafficManager.Custom.AI {
-    using System.Runtime.CompilerServices;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
     using ColossalFramework;
     using CSUtil.Commons;
     using JetBrains.Annotations;
-    using Manager.Impl;
-    using PathFinding;
-    using RedirectionFramework.Attributes;
+    using System.Runtime.CompilerServices;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Custom.PathFinding;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.RedirectionFramework.Attributes;
     using UnityEngine;
 
     [TargetType(typeof(CargoTruckAI))]

--- a/TLM/TLM/Custom/AI/CustomCitizenAI.cs
+++ b/TLM/TLM/Custom/AI/CustomCitizenAI.cs
@@ -1,8 +1,8 @@
 ﻿namespace TrafficManager.Custom.AI {
-    using API.Manager;
     using JetBrains.Annotations;
-    using Manager;
-    using RedirectionFramework.Attributes;
+    using TrafficManager.API.Manager;
+    using TrafficManager.Manager;
+    using TrafficManager.RedirectionFramework.Attributes;
     using UnityEngine;
 
     [TargetType(typeof(CitizenAI))]

--- a/TLM/TLM/Custom/AI/CustomFireTruckAI.cs
+++ b/TLM/TLM/Custom/AI/CustomFireTruckAI.cs
@@ -1,13 +1,13 @@
 ﻿namespace TrafficManager.Custom.AI {
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
     using ColossalFramework;
-    using JetBrains.Annotations;
-    using Manager.Impl;
-    using PathFinding;
-    using RedirectionFramework.Attributes;
-    using UnityEngine;
     using CSUtil.Commons.Benchmark;
+    using JetBrains.Annotations;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Custom.PathFinding;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.RedirectionFramework.Attributes;
+    using UnityEngine;
 
     [TargetType(typeof(FireTruckAI))]
     public class CustomFireTruckAI : CarAI {

--- a/TLM/TLM/Custom/AI/CustomHumanAI.cs
+++ b/TLM/TLM/Custom/AI/CustomHumanAI.cs
@@ -1,18 +1,18 @@
 namespace TrafficManager.Custom.AI {
-    using System.Runtime.CompilerServices;
-    using API.Manager;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
-    using API.TrafficLight;
     using ColossalFramework;
-    using CSUtil.Commons;
     using CSUtil.Commons.Benchmark;
+    using CSUtil.Commons;
     using JetBrains.Annotations;
-    using Manager;
-    using Manager.Impl;
-    using RedirectionFramework.Attributes;
-    using State;
-    using State.ConfigData;
+    using System.Runtime.CompilerServices;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.API.TrafficLight;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.Manager;
+    using TrafficManager.RedirectionFramework.Attributes;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.State;
     using UnityEngine;
 
     [TargetType(typeof(HumanAI))]

--- a/TLM/TLM/Custom/AI/CustomPassengerCarAI.cs
+++ b/TLM/TLM/Custom/AI/CustomPassengerCarAI.cs
@@ -1,15 +1,15 @@
 namespace TrafficManager.Custom.AI {
-    using System;
-    using System.Runtime.CompilerServices;
-    using ColossalFramework;
     using ColossalFramework.Globalization;
     using ColossalFramework.Math;
-    using CSUtil.Commons;
+    using ColossalFramework;
     using CSUtil.Commons.Benchmark;
+    using CSUtil.Commons;
     using JetBrains.Annotations;
-    using Manager.Impl;
-    using RedirectionFramework.Attributes;
-    using State;
+    using System.Runtime.CompilerServices;
+    using System;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.RedirectionFramework.Attributes;
+    using TrafficManager.State;
     using UnityEngine;
 
     // TODO move Parking AI features from here to a distinct manager

--- a/TLM/TLM/Custom/AI/CustomPoliceCarAI.cs
+++ b/TLM/TLM/Custom/AI/CustomPoliceCarAI.cs
@@ -1,11 +1,11 @@
 ﻿namespace TrafficManager.Custom.AI {
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
     using ColossalFramework;
     using JetBrains.Annotations;
-    using Manager.Impl;
-    using PathFinding;
-    using RedirectionFramework.Attributes;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Custom.PathFinding;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.RedirectionFramework.Attributes;
     using UnityEngine;
 
     [TargetType(typeof(PoliceCarAI))]

--- a/TLM/TLM/Custom/AI/CustomPostVanAI.cs
+++ b/TLM/TLM/Custom/AI/CustomPostVanAI.cs
@@ -1,10 +1,10 @@
 ﻿namespace TrafficManager.Custom.AI {
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
     using ColossalFramework;
     using JetBrains.Annotations;
-    using PathFinding;
-    using RedirectionFramework.Attributes;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Custom.PathFinding;
+    using TrafficManager.RedirectionFramework.Attributes;
     using UnityEngine;
 
     [TargetType(typeof(PostVanAI))]

--- a/TLM/TLM/Custom/AI/CustomResidentAI.cs
+++ b/TLM/TLM/Custom/AI/CustomResidentAI.cs
@@ -1,14 +1,14 @@
 ﻿namespace TrafficManager.Custom.AI {
-    using System.Runtime.CompilerServices;
-    using API.Traffic.Enums;
-    using ColossalFramework;
     using ColossalFramework.Math;
+    using ColossalFramework;
     using CSUtil.Commons;
     using JetBrains.Annotations;
-    using Manager.Impl;
-    using RedirectionFramework.Attributes;
-    using State;
-    using State.ConfigData;
+    using System.Runtime.CompilerServices;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.RedirectionFramework.Attributes;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.State;
 
     [TargetType(typeof(ResidentAI))]
     public class CustomResidentAI : ResidentAI {

--- a/TLM/TLM/Custom/AI/CustomRoadBaseAI.cs
+++ b/TLM/TLM/Custom/AI/CustomRoadBaseAI.cs
@@ -1,8 +1,8 @@
 namespace TrafficManager.Custom.AI {
     using ColossalFramework;
-    using RedirectionFramework.Attributes;
-    using UI;
-    using UI.SubTools;
+    using TrafficManager.RedirectionFramework.Attributes;
+    using TrafficManager.UI;
+    using TrafficManager.UI.SubTools;
 
     [TargetType(typeof(RoadBaseAI))]
     public class CustomRoadBaseAI : RoadBaseAI {

--- a/TLM/TLM/Custom/AI/CustomShipAI.cs
+++ b/TLM/TLM/Custom/AI/CustomShipAI.cs
@@ -1,10 +1,10 @@
 ﻿namespace TrafficManager.Custom.AI {
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
     using ColossalFramework;
     using JetBrains.Annotations;
-    using PathFinding;
-    using RedirectionFramework.Attributes;
+    using TrafficManager.Custom.PathFinding;
+    using TrafficManager.RedirectionFramework.Attributes;
     using UnityEngine;
 
     [TargetType(typeof(ShipAI))]

--- a/TLM/TLM/Custom/AI/CustomTaxiAI.cs
+++ b/TLM/TLM/Custom/AI/CustomTaxiAI.cs
@@ -1,10 +1,10 @@
 ﻿namespace TrafficManager.Custom.AI {
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
     using ColossalFramework;
     using JetBrains.Annotations;
-    using PathFinding;
-    using RedirectionFramework.Attributes;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Custom.PathFinding;
+    using TrafficManager.RedirectionFramework.Attributes;
     using UnityEngine;
 
     [TargetType(typeof(TaxiAI))]

--- a/TLM/TLM/Custom/AI/CustomTouristAI.cs
+++ b/TLM/TLM/Custom/AI/CustomTouristAI.cs
@@ -1,14 +1,14 @@
 ﻿namespace TrafficManager.Custom.AI {
     using System.Runtime.CompilerServices;
-    using API.Traffic.Enums;
+    using TrafficManager.API.Traffic.Enums;
     using ColossalFramework;
     using ColossalFramework.Math;
     using CSUtil.Commons;
     using JetBrains.Annotations;
-    using Manager.Impl;
-    using RedirectionFramework.Attributes;
-    using State;
-    using State.ConfigData;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.RedirectionFramework.Attributes;
+    using TrafficManager.State;
+    using TrafficManager.State.ConfigData;
 
     [TargetType(typeof(TouristAI))]
     public class CustomTouristAI : TouristAI {

--- a/TLM/TLM/Custom/AI/CustomTrainAI.cs
+++ b/TLM/TLM/Custom/AI/CustomTrainAI.cs
@@ -1,19 +1,19 @@
 ﻿namespace TrafficManager.Custom.AI {
-    using System;
-    using System.Runtime.CompilerServices;
-    using API.Manager;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
-    using ColossalFramework;
     using ColossalFramework.Math;
+    using ColossalFramework;
     using CSUtil.Commons;
     using JetBrains.Annotations;
-    using Manager;
-    using Manager.Impl;
-    using PathFinding;
-    using RedirectionFramework.Attributes;
-    using State;
-    using State.ConfigData;
+    using System.Runtime.CompilerServices;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Custom.PathFinding;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.Manager;
+    using TrafficManager.RedirectionFramework.Attributes;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.State;
     using UnityEngine;
 
     // TODO inherit from VehicleAI (in order to keep the correct references to `base`)

--- a/TLM/TLM/Custom/AI/CustomTramBaseAI.cs
+++ b/TLM/TLM/Custom/AI/CustomTramBaseAI.cs
@@ -1,19 +1,19 @@
 ﻿namespace TrafficManager.Custom.AI {
-    using System;
-    using System.Runtime.CompilerServices;
-    using API.Manager;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
-    using ColossalFramework;
     using ColossalFramework.Math;
+    using ColossalFramework;
     using CSUtil.Commons;
     using JetBrains.Annotations;
-    using Manager;
-    using Manager.Impl;
-    using PathFinding;
-    using RedirectionFramework.Attributes;
-    using State;
-    using State.ConfigData;
+    using System.Runtime.CompilerServices;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Custom.PathFinding;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.Manager;
+    using TrafficManager.RedirectionFramework.Attributes;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.State;
     using UnityEngine;
 
     // TODO inherit from VehicleAI (in order to keep the correct references to `base`)

--- a/TLM/TLM/Custom/AI/CustomTransportLineAI.cs
+++ b/TLM/TLM/Custom/AI/CustomTransportLineAI.cs
@@ -1,13 +1,13 @@
 ﻿namespace TrafficManager.Custom.AI {
-    using System.Runtime.CompilerServices;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
     using ColossalFramework;
     using CSUtil.Commons;
     using JetBrains.Annotations;
-    using PathFinding;
-    using RedirectionFramework.Attributes;
-    using State.ConfigData;
+    using System.Runtime.CompilerServices;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Custom.PathFinding;
+    using TrafficManager.RedirectionFramework.Attributes;
+    using TrafficManager.State.ConfigData;
     using UnityEngine;
 
     // TODO inherit from NetAI (in order to keep the correct references to `base`)

--- a/TLM/TLM/Custom/AI/CustomVehicleAI.cs
+++ b/TLM/TLM/Custom/AI/CustomVehicleAI.cs
@@ -1,17 +1,17 @@
 ﻿// #define QUEUEDSTATS
 
 namespace TrafficManager.Custom.AI {
-    using System;
-    using System.Runtime.CompilerServices;
-    using ColossalFramework;
     using ColossalFramework.Math;
+    using ColossalFramework;
     using CSUtil.Commons;
     using JetBrains.Annotations;
-    using Manager.Impl;
-    using RedirectionFramework.Attributes;
-    using State;
-    using State.ConfigData;
-    using Traffic;
+    using System.Runtime.CompilerServices;
+    using System;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.RedirectionFramework.Attributes;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.State;
+    using TrafficManager.Traffic;
     using UnityEngine;
 
     // TODO inherit from PrefabAI (in order to keep the correct references to `base`)

--- a/TLM/TLM/Custom/Data/CustomVehicle.cs
+++ b/TLM/TLM/Custom/Data/CustomVehicle.cs
@@ -1,10 +1,10 @@
 ﻿namespace TrafficManager.Custom.Data {
-    using System;
-    using ColossalFramework;
     using ColossalFramework.Math;
+    using ColossalFramework;
     using JetBrains.Annotations;
-    using Manager.Impl;
-    using RedirectionFramework.Attributes;
+    using System;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.RedirectionFramework.Attributes;
     using UnityEngine;
 
     [TargetType(typeof(Vehicle))]

--- a/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
@@ -1,20 +1,20 @@
 ﻿namespace TrafficManager.Custom.PathFinding {
-    using System;
+    using ColossalFramework.Math;
+    using ColossalFramework.UI;
+    using ColossalFramework;
+    using CSUtil.Commons;
     using System.Diagnostics;
     using System.Reflection;
     using System.Threading;
-    using API.Manager;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
-    using API.TrafficLight;
-    using ColossalFramework;
-    using ColossalFramework.Math;
-    using ColossalFramework.UI;
-    using CSUtil.Commons;
-    using Manager;
-    using Manager.Impl;
-    using RedirectionFramework.Attributes;
-    using State;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.API.TrafficLight;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.Manager;
+    using TrafficManager.RedirectionFramework.Attributes;
+    using TrafficManager.State;
     using UnityEngine;
 
 #if DEBUG

--- a/TLM/TLM/Custom/PathFinding/CustomPathManager.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathManager.cs
@@ -2,17 +2,17 @@
 // #define DEBUGPF3
 
 namespace TrafficManager.Custom.PathFinding {
-    using System;
-    using System.Reflection;
-    using System.Threading;
-    using API.Traffic.Data;
-    using ColossalFramework;
     using ColossalFramework.Math;
+    using ColossalFramework;
     using CSUtil.Commons;
     using JetBrains.Annotations;
-    using Manager.Impl;
-    using RedirectionFramework.Attributes;
-    using State;
+    using System.Reflection;
+    using System.Threading;
+    using System;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.RedirectionFramework.Attributes;
+    using TrafficManager.State;
     using UnityEngine;
 
 #if !PF_DIJKSTRA

--- a/TLM/TLM/Geometry/Impl/SegmentEndId.cs
+++ b/TLM/TLM/Geometry/Impl/SegmentEndId.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrafficManager.Geometry.Impl {
-    using API.Traffic;
-    using Traffic;
+    using TrafficManager.API.Traffic;
+    using TrafficManager.Traffic;
 
     public class SegmentEndId : ISegmentEndId {
         public ushort SegmentId { get; protected set; }

--- a/TLM/TLM/LoadingExtension.cs
+++ b/TLM/TLM/LoadingExtension.cs
@@ -1,21 +1,21 @@
 namespace TrafficManager {
-    using System;
-    using System.Collections.Generic;
-    using System.Reflection;
-    using API.Manager;
-    using ColossalFramework;
     using ColossalFramework.UI;
+    using ColossalFramework;
     using CSUtil.Commons;
-    using Custom.PathFinding;
     using Harmony;
     using ICities;
     using JetBrains.Annotations;
-    using Manager.Impl;
-    using RedirectionFramework;
-    using State;
-    using UI;
-    using UI.Localization;
     using Object = UnityEngine.Object;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.Custom.PathFinding;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.RedirectionFramework;
+    using TrafficManager.State;
+    using TrafficManager.UI.Localization;
+    using TrafficManager.UI;
 
     [UsedImplicitly]
     public class LoadingExtension : LoadingExtensionBase {

--- a/TLM/TLM/Manager/AbstractCustomManager.cs
+++ b/TLM/TLM/Manager/AbstractCustomManager.cs
@@ -1,7 +1,7 @@
 ﻿namespace TrafficManager.Manager {
-    using API.Manager;
     using CSUtil.Commons;
     using GenericGameBridge.Factory;
+    using TrafficManager.API.Manager;
 
     /// <summary>
     /// Abstract manager class, supports events before/after loading/saving.

--- a/TLM/TLM/Manager/AbstractFeatureManager.cs
+++ b/TLM/TLM/Manager/AbstractFeatureManager.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.Manager {
-    using API.Manager;
+    using TrafficManager.API.Manager;
 
     /// <summary>
     /// Helper class to ensure that events are always handled in the simulation thread

--- a/TLM/TLM/Manager/AbstractGeometryObservingManager.cs
+++ b/TLM/TLM/Manager/AbstractGeometryObservingManager.cs
@@ -1,14 +1,14 @@
 ﻿namespace TrafficManager.Manager {
-    using System;
-    using API.Geometry;
-    using API.Manager;
-    using API.Traffic.Data;
-    using API.Util;
     using CSUtil.Commons;
-    using Geometry;
     using JetBrains.Annotations;
-    using State.ConfigData;
-    using Util;
+    using System;
+    using TrafficManager.API.Geometry;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Util;
+    using TrafficManager.Geometry;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.Util;
 
     public abstract class AbstractGeometryObservingManager : AbstractCustomManager, IObserver<GeometryUpdate> {
         private IDisposable geoUpdateUnsubscriber;

--- a/TLM/TLM/Manager/Impl/AdvancedParkingManager.cs
+++ b/TLM/TLM/Manager/Impl/AdvancedParkingManager.cs
@@ -1,21 +1,21 @@
 ﻿namespace TrafficManager.Manager.Impl {
-    using System;
-    using API.Manager;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
-    using ColossalFramework;
     using ColossalFramework.Globalization;
     using ColossalFramework.Math;
-    using CSUtil.Commons;
+    using ColossalFramework;
     using CSUtil.Commons.Benchmark;
-    using Custom.AI;
-    using Custom.PathFinding;
+    using CSUtil.Commons;
     using JetBrains.Annotations;
-    using State;
-    using State.ConfigData;
-    using UI;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Custom.AI;
+    using TrafficManager.Custom.PathFinding;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.State;
+    using TrafficManager.UI;
+    using TrafficManager.Util;
     using UnityEngine;
-    using Util;
 
     public class AdvancedParkingManager
         : AbstractFeatureManager,

--- a/TLM/TLM/Manager/Impl/CustomSegmentLightsManager.cs
+++ b/TLM/TLM/Manager/Impl/CustomSegmentLightsManager.cs
@@ -1,13 +1,13 @@
 namespace TrafficManager.Manager.Impl {
-    using System.Collections.Generic;
-    using API.Manager;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
-    using API.TrafficLight;
     using ColossalFramework;
     using CSUtil.Commons;
-    using TrafficLight;
-    using TrafficLight.Impl;
+    using System.Collections.Generic;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.API.TrafficLight;
+    using TrafficManager.TrafficLight.Impl;
+    using TrafficManager.TrafficLight;
 
     /// <summary>
     /// Manages the states of all custom traffic lights on the map

--- a/TLM/TLM/Manager/Impl/ExtBuildingManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtBuildingManager.cs
@@ -1,10 +1,10 @@
 ﻿namespace TrafficManager.Manager.Impl {
-    using System;
-    using API.Manager;
-    using API.Traffic.Data;
     using ColossalFramework;
     using CSUtil.Commons;
-    using State;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.State;
     using UnityEngine;
 
     public class ExtBuildingManager

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -1,16 +1,16 @@
 ﻿namespace TrafficManager.Manager.Impl {
-    using System;
-    using System.Collections.Generic;
-    using API.Manager;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
-    using ColossalFramework;
     using ColossalFramework.Globalization;
-    using CSUtil.Commons;
+    using ColossalFramework;
     using CSUtil.Commons.Benchmark;
-    using Custom.PathFinding;
-    using State;
-    using State.ConfigData;
+    using CSUtil.Commons;
+    using System.Collections.Generic;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Custom.PathFinding;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.State;
     using UnityEngine;
 
     public class ExtCitizenInstanceManager

--- a/TLM/TLM/Manager/Impl/ExtCitizenManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenManager.cs
@@ -1,11 +1,11 @@
 ﻿namespace TrafficManager.Manager.Impl {
-    using System;
-    using System.Collections.Generic;
-    using API.Manager;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
     using ColossalFramework;
     using CSUtil.Commons;
+    using System.Collections.Generic;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
 
 #if DEBUG
     using State.ConfigData;

--- a/TLM/TLM/Manager/Impl/ExtNodeManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtNodeManager.cs
@@ -1,10 +1,10 @@
 namespace TrafficManager.Manager.Impl {
-    using API.Geometry;
-    using API.Manager;
-    using API.Traffic.Data;
     using CSUtil.Commons;
-    using Geometry;
-    using Geometry.Impl;
+    using TrafficManager.API.Geometry;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.Geometry.Impl;
+    using TrafficManager.Geometry;
 
     public class ExtNodeManager
         : AbstractCustomManager,

--- a/TLM/TLM/Manager/Impl/ExtPathManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtPathManager.cs
@@ -1,9 +1,9 @@
 ﻿namespace TrafficManager.Manager.Impl {
-    using System;
-    using API.Manager;
     using ColossalFramework;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.Util;
     using UnityEngine;
-    using Util;
 
     public class ExtPathManager
         : AbstractCustomManager,

--- a/TLM/TLM/Manager/Impl/ExtSegmentEndManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtSegmentEndManager.cs
@@ -1,10 +1,10 @@
 namespace TrafficManager.Manager.Impl {
-    using System;
-    using API.Manager;
-    using API.Traffic.Data;
     using ColossalFramework;
     using CSUtil.Commons;
-    using State.ConfigData;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.State.ConfigData;
     using UnityEngine;
 
     public class ExtSegmentEndManager

--- a/TLM/TLM/Manager/Impl/ExtSegmentManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtSegmentManager.cs
@@ -1,9 +1,9 @@
 namespace TrafficManager.Manager.Impl {
-    using API.Manager;
-    using API.Traffic.Data;
     using ColossalFramework;
     using CSUtil.Commons;
-    using State.ConfigData;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.State.ConfigData;
 
     public class ExtSegmentManager
         : AbstractCustomManager,

--- a/TLM/TLM/Manager/Impl/ExtVehicleManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtVehicleManager.cs
@@ -1,14 +1,14 @@
 ﻿namespace TrafficManager.Manager.Impl {
-    using System;
-    using API.Manager;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
-    using ColossalFramework;
     using ColossalFramework.Math;
+    using ColossalFramework;
     using CSUtil.Commons;
     using JetBrains.Annotations;
-    using State;
-    using State.ConfigData;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.State;
     using UnityEngine;
 
     public class ExtVehicleManager

--- a/TLM/TLM/Manager/Impl/GeometryManager.cs
+++ b/TLM/TLM/Manager/Impl/GeometryManager.cs
@@ -1,16 +1,16 @@
 ﻿namespace TrafficManager.Manager.Impl {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using API.Geometry;
-    using API.Manager;
-    using API.Traffic.Data;
-    using API.Util;
     using ColossalFramework;
     using CSUtil.Commons;
-    using State.ConfigData;
-    using Geometry;
-    using Util;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System;
+    using TrafficManager.API.Geometry;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Util;
+    using TrafficManager.Geometry;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.Util;
 
     public class GeometryManager
         : AbstractCustomManager,

--- a/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
@@ -1,17 +1,17 @@
 namespace TrafficManager.Manager.Impl {
-    using System;
-    using System.Collections.Generic;
-    using API.Geometry;
-    using API.Manager;
-    using API.Traffic;
-    using API.Traffic.Data;
     using ColossalFramework;
     using CSUtil.Commons;
-    using Geometry;
     using JetBrains.Annotations;
-    using State;
-    using State.ConfigData;
-    using Traffic;
+    using System.Collections.Generic;
+    using System;
+    using TrafficManager.API.Geometry;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic;
+    using TrafficManager.Geometry;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.State;
+    using TrafficManager.Traffic;
 
     public class JunctionRestrictionsManager
         : AbstractGeometryObservingManager,

--- a/TLM/TLM/Manager/Impl/LaneArrowManager.cs
+++ b/TLM/TLM/Manager/Impl/LaneArrowManager.cs
@@ -1,16 +1,16 @@
 namespace TrafficManager.Manager.Impl {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using API.Manager;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
     using ColossalFramework;
     using CSUtil.Commons;
     using GenericGameBridge.Service;
-    using State;
-    using UnityEngine;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.State;
     using TrafficManager.Util;
+    using UnityEngine;
 
     public class LaneArrowManager
         : AbstractGeometryObservingManager,

--- a/TLM/TLM/Manager/Impl/LaneConnectionManager.cs
+++ b/TLM/TLM/Manager/Impl/LaneConnectionManager.cs
@@ -1,15 +1,15 @@
 namespace TrafficManager.Manager.Impl {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using API.Manager;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
     using ColossalFramework;
     using CSUtil.Commons;
     using JetBrains.Annotations;
-    using State;
-    using State.ConfigData;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.State;
     using UnityEngine;
 
     public class LaneConnectionManager

--- a/TLM/TLM/Manager/Impl/ManagerFactory.cs
+++ b/TLM/TLM/Manager/Impl/ManagerFactory.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.Manager.Impl {
-    using API.Manager;
+    using TrafficManager.API.Manager;
 
     public class ManagerFactory : IManagerFactory {
         public static IManagerFactory Instance = new ManagerFactory();

--- a/TLM/TLM/Manager/Impl/OptionsManager.cs
+++ b/TLM/TLM/Manager/Impl/OptionsManager.cs
@@ -1,10 +1,10 @@
 namespace TrafficManager.Manager.Impl {
-    using System;
-    using API.Manager;
-    using API.Traffic.Enums;
     using CSUtil.Commons;
-    using State;
-    using UI.Helpers;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.State;
+    using TrafficManager.UI.Helpers;
 
     public class OptionsManager
         : AbstractCustomManager,

--- a/TLM/TLM/Manager/Impl/ParkingRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/ParkingRestrictionsManager.cs
@@ -1,9 +1,9 @@
 ﻿namespace TrafficManager.Manager.Impl {
-    using System;
-    using System.Collections.Generic;
-    using API.Manager;
-    using API.Traffic.Data;
     using CSUtil.Commons;
+    using System.Collections.Generic;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
 
     public class ParkingRestrictionsManager
         : AbstractGeometryObservingManager,

--- a/TLM/TLM/Manager/Impl/RoutingManager.cs
+++ b/TLM/TLM/Manager/Impl/RoutingManager.cs
@@ -1,16 +1,16 @@
 namespace TrafficManager.Manager.Impl {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading;
-    using API.Manager;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
     using ColossalFramework;
     using CSUtil.Commons;
     using JetBrains.Annotations;
-    using State.ConfigData;
-    using State;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.State;
 
     public class RoutingManager
         : AbstractGeometryObservingManager,

--- a/TLM/TLM/Manager/Impl/SegmentEndManager.cs
+++ b/TLM/TLM/Manager/Impl/SegmentEndManager.cs
@@ -1,11 +1,11 @@
 ﻿namespace TrafficManager.Manager.Impl {
-    using System;
-    using API.Manager;
-    using API.Traffic;
     using CSUtil.Commons;
-    using State.ConfigData;
-    using Traffic;
-    using Traffic.Impl;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.Traffic.Impl;
+    using TrafficManager.Traffic;
 
     [Obsolete("should be removed when implementing issue #240")]
     public class SegmentEndManager

--- a/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
+++ b/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
@@ -1,16 +1,16 @@
 namespace TrafficManager.Manager.Impl {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using API.Manager;
-    using API.Traffic.Data;
     using ColossalFramework;
     using CSUtil.Commons;
     using JetBrains.Annotations;
-    using State;
-    using UI.SubTools.SpeedLimits;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.State;
+    using TrafficManager.UI.SubTools.SpeedLimits;
+    using TrafficManager.Util;
     using UnityEngine;
-    using Util;
 #if DEBUG
     using State.ConfigData;
 #endif

--- a/TLM/TLM/Manager/Impl/TrafficLightManager.cs
+++ b/TLM/TLM/Manager/Impl/TrafficLightManager.cs
@@ -1,13 +1,13 @@
 ﻿namespace TrafficManager.Manager.Impl {
-    using System;
+    using CSUtil.Commons;
     using System.Collections.Generic;
     using System.Linq;
-    using API.Manager;
-    using API.Traffic.Enums;
-    using CSUtil.Commons;
-    using State;
-    using State.ConfigData;
-    using Util;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.State;
+    using TrafficManager.Util;
 
     /// <summary>
     /// Manages traffic light toggling

--- a/TLM/TLM/Manager/Impl/TrafficLightSimulationManager.cs
+++ b/TLM/TLM/Manager/Impl/TrafficLightSimulationManager.cs
@@ -1,20 +1,20 @@
 namespace TrafficManager.Manager.Impl {
-    using System;
+    using CSUtil.Commons.Benchmark;
+    using CSUtil.Commons;
+    using ExtVehicleType = global::TrafficManager.Traffic.ExtVehicleType;
+    using static RoadBaseAI;
     using System.Collections.Generic;
     using System.Linq;
-    using API.Manager;
-    using API.Traffic.Enums;
-    using API.TrafficLight;
-    using API.TrafficLight.Data;
-    using CSUtil.Commons;
-    using CSUtil.Commons.Benchmark;
-    using State;
-    using State.ConfigData;
-    using Traffic;
-    using TrafficLight.Impl;
-    using static RoadBaseAI;
-    using ExtVehicleType = global::TrafficManager.Traffic.ExtVehicleType;
+    using System;
     using TimedTrafficLights = global::TrafficManager.TrafficLight.Impl.TimedTrafficLights;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.API.TrafficLight.Data;
+    using TrafficManager.API.TrafficLight;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.State;
+    using TrafficManager.Traffic;
+    using TrafficManager.TrafficLight.Impl;
 
     public class TrafficLightSimulationManager
         : AbstractGeometryObservingManager,

--- a/TLM/TLM/Manager/Impl/TrafficMeasurementManager.cs
+++ b/TLM/TLM/Manager/Impl/TrafficMeasurementManager.cs
@@ -1,10 +1,10 @@
 ﻿namespace TrafficManager.Manager.Impl {
-    using System;
-    using API.Manager;
-    using API.Traffic.Data;
     using ColossalFramework;
     using CSUtil.Commons;
-    using State;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.State;
     using UnityEngine;
 
     public class TrafficMeasurementManager : AbstractCustomManager, ITrafficMeasurementManager {

--- a/TLM/TLM/Manager/Impl/TrafficPriorityManager.cs
+++ b/TLM/TLM/Manager/Impl/TrafficPriorityManager.cs
@@ -1,20 +1,20 @@
 namespace TrafficManager.Manager.Impl {
-    using System;
-    using System.Collections.Generic;
-    using API.Geometry;
-    using API.Manager;
-    using API.Traffic;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
-    using API.TrafficLight;
     using ColossalFramework;
     using CSUtil.Commons;
-    using Geometry;
     using JetBrains.Annotations;
-    using State;
-    using State.ConfigData;
-    using Traffic;
-    using TrafficLight;
+    using System.Collections.Generic;
+    using System;
+    using TrafficManager.API.Geometry;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.API.Traffic;
+    using TrafficManager.API.TrafficLight;
+    using TrafficManager.Geometry;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.State;
+    using TrafficManager.Traffic;
+    using TrafficManager.TrafficLight;
     using UnityEngine;
 
     public class TrafficPriorityManager

--- a/TLM/TLM/Manager/Impl/TurnOnRedManager.cs
+++ b/TLM/TLM/Manager/Impl/TurnOnRedManager.cs
@@ -1,8 +1,8 @@
 namespace TrafficManager.Manager.Impl {
-    using API.Manager;
-    using API.Traffic.Data;
     using CSUtil.Commons;
-    using State.ConfigData;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.State.ConfigData;
 
     public class TurnOnRedManager
         : AbstractGeometryObservingManager,

--- a/TLM/TLM/Manager/Impl/UtilityManager.cs
+++ b/TLM/TLM/Manager/Impl/UtilityManager.cs
@@ -1,10 +1,10 @@
 ﻿namespace TrafficManager.Manager.Impl {
-    using System;
-    using System.Threading;
-    using API.Manager;
     using ColossalFramework;
     using CSUtil.Commons;
-    using State;
+    using System.Threading;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.State;
     using UnityEngine;
 
     public class UtilityManager : AbstractCustomManager, IUtilityManager {

--- a/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
+++ b/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
@@ -1,18 +1,18 @@
 namespace TrafficManager.Manager.Impl {
-    using System;
-    using API.Manager;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
     using ColossalFramework;
-    using CSUtil.Commons;
     using CSUtil.Commons.Benchmark;
-    using Custom.PathFinding;
+    using CSUtil.Commons;
     using JetBrains.Annotations;
-    using State;
-    using State.ConfigData;
-    using UI.SubTools.SpeedLimits;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Custom.PathFinding;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.State;
+    using TrafficManager.UI.SubTools.SpeedLimits;
+    using TrafficManager.Util;
     using UnityEngine;
-    using Util;
 
     public class VehicleBehaviorManager : AbstractCustomManager, IVehicleBehaviorManager {
         public const float MIN_SPEED = 8f * 0.2f; // 10 km/h

--- a/TLM/TLM/Manager/Impl/VehicleRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/VehicleRestrictionsManager.cs
@@ -1,16 +1,16 @@
 ﻿namespace TrafficManager.Manager.Impl {
-    using System;
-    using System.Collections.Generic;
-    using API.Manager;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
     using ColossalFramework;
     using CSUtil.Commons;
-    using JetBrains.Annotations;
-    using State;
-    using Traffic;
-    using Util;
     using ExtVehicleType = global::TrafficManager.API.Traffic.Enums.ExtVehicleType;
+    using JetBrains.Annotations;
+    using System.Collections.Generic;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.State;
+    using TrafficManager.Traffic;
+    using TrafficManager.Util;
 
     public class VehicleRestrictionsManager
         : AbstractGeometryObservingManager,

--- a/TLM/TLM/Patch/_HumanAI/ArriveAtDestinationPatch.cs
+++ b/TLM/TLM/Patch/_HumanAI/ArriveAtDestinationPatch.cs
@@ -2,7 +2,7 @@
     using ColossalFramework;
     using Harmony;
     using JetBrains.Annotations;
-    using State;
+    using TrafficManager.State;
 
     [HarmonyPatch(typeof(HumanAI), "ArriveAtDestination")]
     public class ArriveAtDestinationPatch {

--- a/TLM/TLM/Patch/_RoadBaseAI/GetTrafficLightNodeStatePatch.cs
+++ b/TLM/TLM/Patch/_RoadBaseAI/GetTrafficLightNodeStatePatch.cs
@@ -2,7 +2,7 @@
     using ColossalFramework;
     using Harmony;
     using JetBrains.Annotations;
-    using State;
+    using TrafficManager.State;
     using UnityEngine;
 
     [HarmonyPatch(typeof(RoadBaseAI), "GetTrafficLightNodeState")]

--- a/TLM/TLM/Patch/_RoadBaseAI/SegmentSimulationStepPatch.cs
+++ b/TLM/TLM/Patch/_RoadBaseAI/SegmentSimulationStepPatch.cs
@@ -1,7 +1,7 @@
 ﻿namespace TrafficManager.Patch._RoadBaseAI {
     using ColossalFramework;
     using JetBrains.Annotations;
-    using State;
+    using TrafficManager.State;
 
     // [Harmony] Manually patched because struct references are used
     public class SegmentSimulationStepPatch {

--- a/TLM/TLM/Patch/_RoadBaseAI/SetTrafficLightStatePatch.cs
+++ b/TLM/TLM/Patch/_RoadBaseAI/SetTrafficLightStatePatch.cs
@@ -1,7 +1,7 @@
 ﻿namespace TrafficManager.Patch._RoadBaseAI {
     using Harmony;
     using JetBrains.Annotations;
-    using State;
+    using TrafficManager.State;
     using static RoadBaseAI;
 
     [HarmonyPatch(typeof(RoadBaseAI), "SetTrafficLightState")]

--- a/TLM/TLM/Patch/_RoadBaseAI/TrafficLightSimulationStepPatch.cs
+++ b/TLM/TLM/Patch/_RoadBaseAI/TrafficLightSimulationStepPatch.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrafficManager.Patch._RoadBaseAI {
     using JetBrains.Annotations;
-    using State;
+    using TrafficManager.State;
 
     // [Harmony] Manually patched because struct references are used
     public class TrafficLightSimulationStepPatch {

--- a/TLM/TLM/Patch/_RoadBaseAI/UpdateLanesPatch.cs
+++ b/TLM/TLM/Patch/_RoadBaseAI/UpdateLanesPatch.cs
@@ -2,7 +2,7 @@
     using ColossalFramework;
     using Harmony;
     using JetBrains.Annotations;
-    using State;
+    using TrafficManager.State;
 
     [HarmonyPatch(typeof(RoadBaseAI), "UpdateLanes")]
     [UsedImplicitly]

--- a/TLM/TLM/Patch/_RoadBaseAI/UpdateNodePatch.cs
+++ b/TLM/TLM/Patch/_RoadBaseAI/UpdateNodePatch.cs
@@ -2,8 +2,8 @@ namespace TrafficManager.Patch._RoadBaseAI {
     using ColossalFramework;
     using Harmony;
     using JetBrains.Annotations;
-    using Manager.Impl;
-    using State;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.State;
 
     [HarmonyPatch(typeof(RoadBaseAI), "UpdateNode")]
     [UsedImplicitly]

--- a/TLM/TLM/Patch/_TrainTrackBaseAI/LevelCrossingSimulationStepPatch.cs
+++ b/TLM/TLM/Patch/_TrainTrackBaseAI/LevelCrossingSimulationStepPatch.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrafficManager.Patch._TrainTrackBase {
     using JetBrains.Annotations;
-    using State;
+    using TrafficManager.State;
 
     // [Harmony] Manually patched because struct references are used
     public class LevelCrossingSimulationStepPatch {

--- a/TLM/TLM/State/ConfigData/DebugSettings.cs
+++ b/TLM/TLM/State/ConfigData/DebugSettings.cs
@@ -1,9 +1,9 @@
 namespace TrafficManager.State.ConfigData {
-    using System;
-    using API.Traffic.Enums;
+    using ExtVehicleType = TrafficManager.Traffic.ExtVehicleType;
     using JetBrains.Annotations;
-    using Traffic;
-    using ExtVehicleType = Traffic.ExtVehicleType;
+    using System;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Traffic;
 
 #if DEBUG
     /// <summary>
@@ -12,7 +12,7 @@ namespace TrafficManager.State.ConfigData {
     public class DebugSettings {
         /// <summary>
         /// Do not use directly.
-        /// Use DebugSwitch.<EnumName>.Get() to access the switch values
+        /// Use DebugSwitch.$EnumName$.Get() to access the switch values.
         /// </summary>
         public bool[] Switches = {
             false, // 0: path-finding debug log

--- a/TLM/TLM/State/ConfigData/DynamicLaneSelection.cs
+++ b/TLM/TLM/State/ConfigData/DynamicLaneSelection.cs
@@ -1,6 +1,5 @@
 ﻿namespace TrafficManager.State.ConfigData {
-    using API.Traffic.Data;
-    using UI.SubTools.SpeedLimits;
+    using TrafficManager.API.Traffic.Data;
 
     public class DynamicLaneSelection {
         /// <summary>

--- a/TLM/TLM/State/ConfigData/Main.cs
+++ b/TLM/TLM/State/ConfigData/Main.cs
@@ -1,8 +1,8 @@
 ﻿namespace TrafficManager.State.ConfigData {
     using System.Collections.Generic;
     using System.Linq;
-    using UI.MainMenu;
-    using UI.SubTools.SpeedLimits;
+    using TrafficManager.UI.MainMenu;
+    using TrafficManager.UI.SubTools.SpeedLimits;
 
     public class Main {
         /// <summary>

--- a/TLM/TLM/State/ConfigData/TimedTrafficLights.cs
+++ b/TLM/TLM/State/ConfigData/TimedTrafficLights.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.State.ConfigData {
-    using API.Traffic.Enums;
+    using TrafficManager.API.Traffic.Enums;
 
     public class TimedTrafficLights {
         /// <summary>

--- a/TLM/TLM/State/Configuration.cs
+++ b/TLM/TLM/State/Configuration.cs
@@ -1,11 +1,11 @@
 // TODO this class should be moved to TrafficManager.State, but the deserialization fails if we just do that now. Anyway, we should get rid of these crazy lists of arrays. So let's move the class when we decide rework the load/save system.
 namespace TrafficManager {
-    using System;
-    using System.Collections.Generic;
-    using API.Traffic.Data;
     using JetBrains.Annotations;
-    using State;
-    using Traffic;
+    using System.Collections.Generic;
+    using System;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.State;
+    using TrafficManager.Traffic;
 
     [Serializable]
     public class Configuration {

--- a/TLM/TLM/State/Flags.cs
+++ b/TLM/TLM/State/Flags.cs
@@ -1,15 +1,15 @@
 ﻿// #define DEBUGFLAGS
 
 namespace TrafficManager.State {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using API.Traffic.Enums;
     using ColossalFramework;
-    using ConfigData;
     using CSUtil.Commons;
     using JetBrains.Annotations;
-    using Manager.Impl;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.State.ConfigData;
 
     [Obsolete]
     public class Flags {

--- a/TLM/TLM/State/GlobalConfig.cs
+++ b/TLM/TLM/State/GlobalConfig.cs
@@ -1,11 +1,11 @@
 ﻿namespace TrafficManager.State {
-    using System;
-    using System.IO;
-    using System.Xml.Serialization;
     using CSUtil.Commons;
     using JetBrains.Annotations;
-    using State.ConfigData;
-    using Util;
+    using System.IO;
+    using System.Xml.Serialization;
+    using System;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.Util;
 
     [XmlRootAttribute("GlobalConfig", Namespace = "http://www.viathinksoft.de/tmpe", IsNullable = false)]
     public class GlobalConfig : GenericObservable<GlobalConfig> {

--- a/TLM/TLM/State/Keybinds/Keybind.cs
+++ b/TLM/TLM/State/Keybinds/Keybind.cs
@@ -1,7 +1,7 @@
 namespace TrafficManager.State.Keybinds {
-    using ColossalFramework;
     using ColossalFramework.UI;
-    using UI;
+    using ColossalFramework;
+    using TrafficManager.UI;
     using UnityEngine;
 
     /// <summary>

--- a/TLM/TLM/State/Keybinds/KeybindSettingsPage.cs
+++ b/TLM/TLM/State/Keybinds/KeybindSettingsPage.cs
@@ -1,5 +1,5 @@
 namespace TrafficManager.State.Keybinds {
-    using UI;
+    using TrafficManager.UI;
 
     public class KeybindSettingsPage : KeybindSettingsBase {
         private void Awake() {

--- a/TLM/TLM/State/Keybinds/KeybindUI.cs
+++ b/TLM/TLM/State/Keybinds/KeybindUI.cs
@@ -1,12 +1,12 @@
 namespace TrafficManager.State.Keybinds {
-    using System;
+    using ColossalFramework.UI;
+    using ColossalFramework;
+    using CSUtil.Commons;
     using System.Linq;
     using System.Reflection;
     using System.Text.RegularExpressions;
-    using ColossalFramework;
-    using ColossalFramework.UI;
-    using CSUtil.Commons;
-    using UI;
+    using System;
+    using TrafficManager.UI;
     using UnityEngine;
 
     /// <summary>

--- a/TLM/TLM/State/Options.cs
+++ b/TLM/TLM/State/Options.cs
@@ -1,13 +1,13 @@
 namespace TrafficManager.State {
-    using System.Collections.Generic;
-    using System.Reflection;
-    using API.Traffic.Enums;
     using ColossalFramework.UI;
     using CSUtil.Commons;
     using ICities;
-    using UI;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.UI.Helpers;
+    using TrafficManager.UI;
     using UnityEngine;
-    using UI.Helpers;
 
     public class Options : MonoBehaviour {
 #if DEBUG

--- a/TLM/TLM/State/OptionsTabs/OptionsGameplayTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsGameplayTab.cs
@@ -2,9 +2,9 @@ namespace TrafficManager.State {
     using ColossalFramework.UI;
     using CSUtil.Commons;
     using ICities;
-    using Manager.Impl;
-    using UI;
-    using UI.Helpers;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.UI.Helpers;
+    using TrafficManager.UI;
     using UnityEngine;
 
     public static class OptionsGameplayTab {

--- a/TLM/TLM/State/OptionsTabs/OptionsGeneralTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsGeneralTab.cs
@@ -3,10 +3,10 @@ namespace TrafficManager.State {
     using CSUtil.Commons;
     using ICities;
     using JetBrains.Annotations;
-    using UI;
-    using UI.SubTools.SpeedLimits;
+    using TrafficManager.UI.Helpers;
+    using TrafficManager.UI.SubTools.SpeedLimits;
+    using TrafficManager.UI;
     using UnityEngine;
-    using UI.Helpers;
 
     public static class OptionsGeneralTab {
         private static UICheckBox _instantEffectsToggle;

--- a/TLM/TLM/State/OptionsTabs/OptionsKeybindsTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsKeybindsTab.cs
@@ -1,9 +1,9 @@
 namespace TrafficManager.State {
     using ColossalFramework.UI;
     using ICities;
-    using Keybinds;
-    using UI;
-    using UI.Helpers;
+    using TrafficManager.State.Keybinds;
+    using TrafficManager.UI.Helpers;
+    using TrafficManager.UI;
 
     public static class OptionsKeybindsTab {
         internal static void MakeSettings_Keybinds(ExtUITabstrip tabStrip) {

--- a/TLM/TLM/State/OptionsTabs/OptionsMaintenanceTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsMaintenanceTab.cs
@@ -1,12 +1,12 @@
 namespace TrafficManager.State {
     using ColossalFramework.UI;
-    using CSUtil.Commons;
     using CSUtil.Commons.Benchmark;
+    using CSUtil.Commons;
     using ICities;
     using JetBrains.Annotations;
-    using Manager.Impl;
-    using UI;
-    using UI.Helpers;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.UI.Helpers;
+    using TrafficManager.UI;
 
     public static class OptionsMaintenanceTab {
         [UsedImplicitly]

--- a/TLM/TLM/State/OptionsTabs/OptionsMassEditTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsMassEditTab.cs
@@ -1,7 +1,7 @@
 namespace TrafficManager.State {
     using ICities;
-    using UI;
-    using UI.Helpers;
+    using TrafficManager.UI.Helpers;
+    using TrafficManager.UI;
 
     public static class OptionsMassEditTab {
         public static CheckboxOption RoundAboutQuickFix_DedicatedExitLanes =

--- a/TLM/TLM/State/OptionsTabs/OptionsOverlaysTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsOverlaysTab.cs
@@ -2,8 +2,8 @@ namespace TrafficManager.State {
     using ColossalFramework.UI;
     using CSUtil.Commons;
     using JetBrains.Annotations;
-    using UI;
-    using UI.Helpers;
+    using TrafficManager.UI.Helpers;
+    using TrafficManager.UI;
 
     public static class OptionsOverlaysTab {
         private static UICheckBox _prioritySignsOverlayToggle;

--- a/TLM/TLM/State/OptionsTabs/OptionsVehicleRestrictionsTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsVehicleRestrictionsTab.cs
@@ -1,12 +1,12 @@
 namespace TrafficManager.State {
-    using API.Traffic.Enums;
     using ColossalFramework.UI;
     using CSUtil.Commons;
     using ICities;
-    using Manager.Impl;
-    using UI;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.UI.Helpers;
+    using TrafficManager.UI;
     using UnityEngine;
-    using UI.Helpers;
 
     public static class OptionsVehicleRestrictionsTab {
         private static UICheckBox _relaxedBussesToggle;

--- a/TLM/TLM/State/SerializableDataExtension.cs
+++ b/TLM/TLM/State/SerializableDataExtension.cs
@@ -1,13 +1,13 @@
 ﻿namespace TrafficManager.State {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Runtime.Serialization.Formatters.Binary;
-    using API.Manager;
     using CSUtil.Commons;
     using ICities;
     using JetBrains.Annotations;
-    using Manager.Impl;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.Manager.Impl;
 
     [UsedImplicitly]
     public class SerializableDataExtension

--- a/TLM/TLM/ThreadingExtension.cs
+++ b/TLM/TLM/ThreadingExtension.cs
@@ -1,18 +1,18 @@
 namespace TrafficManager {
-    using System.Collections.Generic;
-    using System.Reflection;
-    using API.Manager;
-    using ColossalFramework;
     using ColossalFramework.UI;
-    using CSUtil.Commons;
+    using ColossalFramework;
     using CSUtil.Commons.Benchmark;
+    using CSUtil.Commons;
     using ICities;
     using JetBrains.Annotations;
-    using RedirectionFramework;
-    using State;
-    using UI;
-    using UnityEngine;
     using static LoadingExtension;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using TrafficManager.API.Manager;
+    using TrafficManager.RedirectionFramework;
+    using TrafficManager.State;
+    using TrafficManager.UI;
+    using UnityEngine;
 
     [UsedImplicitly]
     public sealed class ThreadingExtension : ThreadingExtensionBase {

--- a/TLM/TLM/Traffic/ExtVehicleType.cs
+++ b/TLM/TLM/Traffic/ExtVehicleType.cs
@@ -5,10 +5,10 @@
     /// <summary>
     /// This Enum is kept for save compatibility.
     /// DO NOT USE.
-    /// Please use TMPE.API.Traffic.Enums.ExtVehicleType
+    /// Please use TMPE.API.Traffic.Enums.ExtVehicleType.
     /// </summary>
     [Flags]
-    [Obsolete]
+    [Obsolete("For save compatibility. Instead use Traffic.Enums.ExtVehicleType.")]
     public enum ExtVehicleType {
         None = 0,
         PassengerCar = 1,

--- a/TLM/TLM/Traffic/Impl/SegmentEnd.cs
+++ b/TLM/TLM/Traffic/Impl/SegmentEnd.cs
@@ -1,18 +1,18 @@
 namespace TrafficManager.Traffic.Impl {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using API.Manager;
-    using API.Traffic;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
     using ColossalFramework;
     using CSUtil.Commons;
-    using Geometry.Impl;
     using JetBrains.Annotations;
-    using Manager.Impl;
-    using State;
-    using Util;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.API.Traffic;
+    using TrafficManager.Geometry.Impl;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.State;
+    using TrafficManager.Util;
 
     /// <summary>
     /// A segment end describes a directional traffic segment connected to a controlled node

--- a/TLM/TLM/TrafficLight/Impl/CustomSegment.cs
+++ b/TLM/TLM/TrafficLight/Impl/CustomSegment.cs
@@ -1,5 +1,5 @@
 namespace TrafficManager.TrafficLight.Impl {
-    using API.TrafficLight;
+    using TrafficManager.API.TrafficLight;
 
     internal class CustomSegment {
         public ICustomSegmentLights StartNodeLights;

--- a/TLM/TLM/TrafficLight/Impl/CustomSegmentLight.cs
+++ b/TLM/TLM/TrafficLight/Impl/CustomSegmentLight.cs
@@ -1,15 +1,15 @@
 // #define DEBUGVISUALS
 
 namespace TrafficManager.TrafficLight.Impl {
-    using System;
-    using API.Manager;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
-    using API.TrafficLight;
     using ColossalFramework;
     using CSUtil.Commons;
     using JetBrains.Annotations;
-    using State.ConfigData;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.API.TrafficLight;
+    using TrafficManager.State.ConfigData;
 
     /// <summary>
     /// Represents the traffic light (left, forward, right) at a specific segment end

--- a/TLM/TLM/TrafficLight/Impl/CustomSegmentLights.cs
+++ b/TLM/TLM/TrafficLight/Impl/CustomSegmentLights.cs
@@ -1,18 +1,18 @@
 // #define DEBUGGET
 
 namespace TrafficManager.TrafficLight.Impl {
-    using System;
-    using System.Collections.Generic;
-    using API.Manager;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
-    using API.TrafficLight;
     using ColossalFramework;
     using CSUtil.Commons;
-    using Geometry.Impl;
     using JetBrains.Annotations;
-    using State.ConfigData;
-    using Util;
+    using System.Collections.Generic;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.API.TrafficLight;
+    using TrafficManager.Geometry.Impl;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.Util;
 
     /// <summary>
     /// Represents the set of custom traffic lights located at a node

--- a/TLM/TLM/TrafficLight/Impl/TimedTrafficLights.cs
+++ b/TLM/TLM/TrafficLight/Impl/TimedTrafficLights.cs
@@ -1,20 +1,20 @@
 namespace TrafficManager.TrafficLight.Impl {
-    using System;
+    using CSUtil.Commons;
+    using GenericGameBridge.Service;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
-    using API.Manager;
-    using API.Traffic;
-    using API.Traffic.Enums;
-    using API.TrafficLight;
-    using CSUtil.Commons;
-    using GenericGameBridge.Service;
-    using Geometry.Impl;
-    using Manager.Impl;
-    using State.ConfigData;
-    using Traffic;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.API.Traffic;
+    using TrafficManager.API.TrafficLight;
+    using TrafficManager.Geometry.Impl;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.Traffic;
+    using TrafficManager.Util;
     using UnityEngine;
-    using Util;
 
     // TODO define TimedTrafficLights per node group, not per individual nodes
     public class TimedTrafficLights : ITimedTrafficLights {

--- a/TLM/TLM/TrafficLight/Impl/TimedTrafficLightsStep.cs
+++ b/TLM/TLM/TrafficLight/Impl/TimedTrafficLightsStep.cs
@@ -1,19 +1,19 @@
 namespace TrafficManager.TrafficLight.Impl {
-    using System;
+    using CSUtil.Commons.Benchmark;
+    using CSUtil.Commons;
+    using ExtVehicleType = global::TrafficManager.API.Traffic.Enums.ExtVehicleType;
     using System.Collections.Generic;
     using System.Linq;
-    using API.Manager;
-    using API.Traffic;
-    using API.Traffic.Enums;
-    using API.TrafficLight;
-    using CSUtil.Commons;
-    using CSUtil.Commons.Benchmark;
-    using Manager.Impl;
-    using State;
-    using State.ConfigData;
-    using Traffic;
-    using Util;
-    using ExtVehicleType = global::TrafficManager.API.Traffic.Enums.ExtVehicleType;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.API.Traffic;
+    using TrafficManager.API.TrafficLight;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.State;
+    using TrafficManager.Traffic;
+    using TrafficManager.Util;
 
     // TODO class should be completely reworked, approx. in version 1.10
     public class TimedTrafficLightsStep

--- a/TLM/TLM/TrafficManagerMod.cs
+++ b/TLM/TLM/TrafficManagerMod.cs
@@ -1,15 +1,14 @@
-namespace TrafficManager
-{
-    using System;
-    using System.Reflection;
+namespace TrafficManager {
     using ColossalFramework.Globalization;
     using ColossalFramework.UI;
     using CSUtil.Commons;
     using ICities;
     using JetBrains.Annotations;
-    using State;
+    using System.Reflection;
+    using System;
+    using TrafficManager.State;
     using TrafficManager.UI;
-    using Util;
+    using TrafficManager.Util;
 
     public class TrafficManagerMod : IUserMod {
 #if LABS

--- a/TLM/TLM/UI/Helpers/SerializableUIOptionBase.cs
+++ b/TLM/TLM/UI/Helpers/SerializableUIOptionBase.cs
@@ -1,11 +1,11 @@
 namespace TrafficManager.UI.Helpers {
     using ColossalFramework.UI;
+    using ColossalFramework;
     using CSUtil.Commons;
     using ICities;
-    using State;
     using System.Reflection;
     using System;
-    using ColossalFramework;
+    using TrafficManager.State;
 
     public abstract class SerializableUIOptionBase<TVal, TUI> : ILegacySerializableOption
         where TUI : UIComponent {

--- a/TLM/TLM/UI/IncompatibleModsPanel.cs
+++ b/TLM/TLM/UI/IncompatibleModsPanel.cs
@@ -1,15 +1,14 @@
-namespace TrafficManager.UI
-{
-    using System;
-    using System.Collections.Generic;
-    using ColossalFramework;
+namespace TrafficManager.UI {
     using ColossalFramework.IO;
     using ColossalFramework.PlatformServices;
     using ColossalFramework.UI;
+    using ColossalFramework;
     using CSUtil.Commons;
-    using State;
-    using UnityEngine;
     using static ColossalFramework.Plugins.PluginManager;
+    using System.Collections.Generic;
+    using System;
+    using TrafficManager.State;
+    using UnityEngine;
 
     public class IncompatibleModsPanel : UIPanel {
         private const ulong LOCAL_MOD = ulong.MaxValue;

--- a/TLM/TLM/UI/LinearSpriteButton.cs
+++ b/TLM/TLM/UI/LinearSpriteButton.cs
@@ -1,10 +1,10 @@
 ﻿namespace TrafficManager.UI {
-    using System;
     using ColossalFramework.UI;
     using CSUtil.Commons;
-    using State.Keybinds;
+    using System;
+    using TrafficManager.State.Keybinds;
+    using TrafficManager.Util;
     using UnityEngine;
-    using Util;
 
     public abstract class LinearSpriteButton : UIButton {
         protected enum ButtonMouseState {

--- a/TLM/TLM/UI/Localization/Translation.cs
+++ b/TLM/TLM/UI/Localization/Translation.cs
@@ -6,7 +6,7 @@ namespace TrafficManager.UI {
     using ColossalFramework;
     using ColossalFramework.Globalization;
     using CSUtil.Commons;
-    using State;
+    using TrafficManager.State;
 
     /// <summary>
     /// Adding a new language step by step:

--- a/TLM/TLM/UI/MainMenu/ClearTrafficButton.cs
+++ b/TLM/TLM/UI/MainMenu/ClearTrafficButton.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrafficManager.UI.MainMenu {
     using ColossalFramework.UI;
-    using Manager.Impl;
+    using TrafficManager.Manager.Impl;
 
     public class ClearTrafficButton : MenuButton {
         public override bool Active => false;

--- a/TLM/TLM/UI/MainMenu/DespawnButton.cs
+++ b/TLM/TLM/UI/MainMenu/DespawnButton.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrafficManager.UI.MainMenu {
     using ColossalFramework.UI;
-    using State;
+    using TrafficManager.State;
 
     public class DespawnButton : MenuButton {
         public override bool Active => false;

--- a/TLM/TLM/UI/MainMenu/JunctionRestrictionsButton.cs
+++ b/TLM/TLM/UI/MainMenu/JunctionRestrictionsButton.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrafficManager.UI.MainMenu {
-    using State;
-    using State.Keybinds;
+    using TrafficManager.State;
+    using TrafficManager.State.Keybinds;
 
     public class JunctionRestrictionsButton : MenuToolModeButton {
         protected override ToolMode ToolMode => ToolMode.JunctionRestrictions;

--- a/TLM/TLM/UI/MainMenu/LaneArrowsButton.cs
+++ b/TLM/TLM/UI/MainMenu/LaneArrowsButton.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.UI.MainMenu {
-    using State.Keybinds;
+    using TrafficManager.State.Keybinds;
 
     public class LaneArrowsButton : MenuToolModeButton {
         protected override ToolMode ToolMode => ToolMode.LaneChange;

--- a/TLM/TLM/UI/MainMenu/LaneConnectorButton.cs
+++ b/TLM/TLM/UI/MainMenu/LaneConnectorButton.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrafficManager.UI.MainMenu {
-    using State;
-    using State.Keybinds;
+    using TrafficManager.State;
+    using TrafficManager.State.Keybinds;
 
     public class LaneConnectorButton : MenuToolModeButton {
         protected override ToolMode ToolMode => ToolMode.LaneConnector;

--- a/TLM/TLM/UI/MainMenu/MainMenuPanel.cs
+++ b/TLM/TLM/UI/MainMenu/MainMenuPanel.cs
@@ -1,12 +1,12 @@
 // #define QUEUEDSTATS
 
 namespace TrafficManager.UI.MainMenu {
-    using System;
-    using API.Util;
     using ColossalFramework.UI;
     using CSUtil.Commons;
-    using State;
-    using State.Keybinds;
+    using System;
+    using TrafficManager.API.Util;
+    using TrafficManager.State.Keybinds;
+    using TrafficManager.State;
     using UnityEngine;
 
     public class MainMenuPanel

--- a/TLM/TLM/UI/MainMenu/ManualTrafficLightsButton.cs
+++ b/TLM/TLM/UI/MainMenu/ManualTrafficLightsButton.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.UI.MainMenu {
-    using State;
+    using TrafficManager.State;
 
     public class ManualTrafficLightsButton : MenuToolModeButton {
         protected override ToolMode ToolMode => ToolMode.ManualSwitch;

--- a/TLM/TLM/UI/MainMenu/MenuButton.cs
+++ b/TLM/TLM/UI/MainMenu/MenuButton.cs
@@ -1,7 +1,7 @@
 ﻿namespace TrafficManager.UI.MainMenu {
-    using System;
     using ColossalFramework.UI;
-    using Textures;
+    using System;
+    using TrafficManager.UI.Textures;
     using UnityEngine;
 
     public abstract class MenuButton : LinearSpriteButton {

--- a/TLM/TLM/UI/MainMenu/ParkingRestrictionsButton.cs
+++ b/TLM/TLM/UI/MainMenu/ParkingRestrictionsButton.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.UI.MainMenu {
-    using State;
+    using TrafficManager.State;
 
     public class ParkingRestrictionsButton : MenuToolModeButton {
         protected override ToolMode ToolMode => ToolMode.ParkingRestrictions;

--- a/TLM/TLM/UI/MainMenu/PrioritySignsButton.cs
+++ b/TLM/TLM/UI/MainMenu/PrioritySignsButton.cs
@@ -1,6 +1,6 @@
 namespace TrafficManager.UI.MainMenu {
-    using State;
-    using State.Keybinds;
+    using TrafficManager.State;
+    using TrafficManager.State.Keybinds;
 
     public class PrioritySignsButton : MenuToolModeButton {
         protected override ToolMode ToolMode => ToolMode.AddPrioritySigns;

--- a/TLM/TLM/UI/MainMenu/SpeedLimitsButton.cs
+++ b/TLM/TLM/UI/MainMenu/SpeedLimitsButton.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrafficManager.UI.MainMenu {
-    using State;
-    using State.Keybinds;
+    using TrafficManager.State;
+    using TrafficManager.State.Keybinds;
 
     public class SpeedLimitsButton : MenuToolModeButton {
         protected override ToolMode ToolMode => ToolMode.SpeedLimits;

--- a/TLM/TLM/UI/MainMenu/StatsLabel.cs
+++ b/TLM/TLM/UI/MainMenu/StatsLabel.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrafficManager.UI.MainMenu {
     using ColossalFramework.UI;
-    using Custom.PathFinding;
+    using TrafficManager.Custom.PathFinding;
     using UnityEngine;
 
     public class StatsLabel : UILabel {

--- a/TLM/TLM/UI/MainMenu/TimedTrafficLightsButton.cs
+++ b/TLM/TLM/UI/MainMenu/TimedTrafficLightsButton.cs
@@ -1,5 +1,5 @@
 namespace TrafficManager.UI.MainMenu {
-    using State;
+    using TrafficManager.State;
 
     public class TimedTrafficLightsButton : MenuToolModeButton {
         protected override ToolMode ToolMode => ToolMode.TimedLightsSelectNode;

--- a/TLM/TLM/UI/MainMenu/ToggleTrafficLightsButton.cs
+++ b/TLM/TLM/UI/MainMenu/ToggleTrafficLightsButton.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.UI.MainMenu {
-    using State.Keybinds;
+    using TrafficManager.State.Keybinds;
 
     public class ToggleTrafficLightsButton : MenuToolModeButton {
         protected override ToolMode ToolMode => ToolMode.SwitchTrafficLight;

--- a/TLM/TLM/UI/MainMenu/VehicleRestrictionsButton.cs
+++ b/TLM/TLM/UI/MainMenu/VehicleRestrictionsButton.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.UI.MainMenu {
-    using State;
+    using TrafficManager.State;
 
     public class VehicleRestrictionsButton : MenuToolModeButton {
         protected override ToolMode ToolMode => ToolMode.VehicleRestrictions;

--- a/TLM/TLM/UI/RemoveCitizenInstanceButtonExtender.cs
+++ b/TLM/TLM/UI/RemoveCitizenInstanceButtonExtender.cs
@@ -1,8 +1,8 @@
 ﻿namespace TrafficManager.UI {
-    using System.Collections.Generic;
     using ColossalFramework.UI;
     using CSUtil.Commons;
-    using Textures;
+    using System.Collections.Generic;
+    using TrafficManager.UI.Textures;
     using UnityEngine;
 
     public class RemoveCitizenInstanceButtonExtender : MonoBehaviour {

--- a/TLM/TLM/UI/RemoveVehicleButtonExtender.cs
+++ b/TLM/TLM/UI/RemoveVehicleButtonExtender.cs
@@ -1,8 +1,8 @@
 ﻿namespace TrafficManager.UI {
-    using System.Collections.Generic;
     using ColossalFramework.UI;
     using CSUtil.Commons;
-    using Textures;
+    using System.Collections.Generic;
+    using TrafficManager.UI.Textures;
     using UnityEngine;
 
     public class RemoveVehicleButtonExtender : MonoBehaviour {

--- a/TLM/TLM/UI/SubTool.cs
+++ b/TLM/TLM/UI/SubTool.cs
@@ -1,7 +1,7 @@
 namespace TrafficManager.UI {
     using ColossalFramework.UI;
     using JetBrains.Annotations;
-    using Textures;
+    using TrafficManager.UI.Textures;
     using UnityEngine;
 
     public abstract class SubTool {

--- a/TLM/TLM/UI/SubTools/JunctionRestrictionsTool.cs
+++ b/TLM/TLM/UI/SubTools/JunctionRestrictionsTool.cs
@@ -1,12 +1,12 @@
 namespace TrafficManager.UI.SubTools {
-    using System.Collections.Generic;
-    using API.Manager;
     using ColossalFramework;
     using CSUtil.Commons;
-    using Manager.Impl;
-    using State;
-    using State.ConfigData;
-    using Textures;
+    using System.Collections.Generic;
+    using TrafficManager.API.Manager;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.State;
+    using TrafficManager.UI.Textures;
     using UnityEngine;
 
     public class JunctionRestrictionsTool : SubTool {

--- a/TLM/TLM/UI/SubTools/LaneArrowTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneArrowTool.cs
@@ -1,12 +1,12 @@
 namespace TrafficManager.UI.SubTools {
-    using System.Collections.Generic;
-    using API.Traffic.Enums;
     using ColossalFramework;
     using CSUtil.Commons;
     using GenericGameBridge.Service;
-    using Manager.Impl;
-    using State;
+    using System.Collections.Generic;
     using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.State;
     using UnityEngine;
 
     public class LaneArrowTool : SubTool {

--- a/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
@@ -1,16 +1,16 @@
 namespace TrafficManager.UI.SubTools {
-    using System.Collections.Generic;
-    using System.Linq;
-    using ColossalFramework;
     using ColossalFramework.Math;
+    using ColossalFramework;
     using CSUtil.Commons;
     using JetBrains.Annotations;
-    using Manager.Impl;
-    using State;
-    using State.ConfigData;
-    using State.Keybinds;
+    using System.Collections.Generic;
+    using System.Linq;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.State.Keybinds;
+    using TrafficManager.State;
+    using TrafficManager.Util.Caching;
     using UnityEngine;
-    using Util.Caching;
 
     public class LaneConnectorTool : SubTool {
         private enum MarkerSelectionMode {

--- a/TLM/TLM/UI/SubTools/ManualTrafficLightsTool.cs
+++ b/TLM/TLM/UI/SubTools/ManualTrafficLightsTool.cs
@@ -1,13 +1,13 @@
 ﻿namespace TrafficManager.UI.SubTools {
-    using API.Manager;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
-    using API.TrafficLight;
     using ColossalFramework;
     using JetBrains.Annotations;
-    using Manager.Impl;
-    using Textures;
     using TrafficLight;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.API.TrafficLight;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.UI.Textures;
     using UnityEngine;
 
     public class ManualTrafficLightsTool : SubTool {

--- a/TLM/TLM/UI/SubTools/ParkingRestrictionsTool.cs
+++ b/TLM/TLM/UI/SubTools/ParkingRestrictionsTool.cs
@@ -1,13 +1,13 @@
 ﻿namespace TrafficManager.UI.SubTools {
-    using System.Collections.Generic;
     using ColossalFramework;
-    using Manager.Impl;
-    using State;
-    using Textures;
-    using UnityEngine;
-    using Util;
-    using Util.Caching;
     using static Util.SegmentLaneTraverser;
+    using System.Collections.Generic;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.State;
+    using TrafficManager.UI.Textures;
+    using TrafficManager.Util.Caching;
+    using TrafficManager.Util;
+    using UnityEngine;
 
     public class ParkingRestrictionsTool : SubTool {
         private readonly Dictionary<ushort, Dictionary<NetInfo.Direction, Vector3>> segmentCenterByDir

--- a/TLM/TLM/UI/SubTools/PrioritySignsTool.cs
+++ b/TLM/TLM/UI/SubTools/PrioritySignsTool.cs
@@ -1,17 +1,17 @@
 namespace TrafficManager.UI.SubTools {
-    using System;
-    using System.Collections.Generic;
-    using API.Manager;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
     using ColossalFramework;
     using CSUtil.Commons;
-    using Manager.Impl;
-    using State;
-    using Textures;
-    using UnityEngine;
-    using Util;
     using static Util.SegmentTraverser;
+    using System.Collections.Generic;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.State;
+    using TrafficManager.UI.Textures;
+    using TrafficManager.Util;
+    using UnityEngine;
 
     public class PrioritySignsTool : SubTool {
         private enum PrioritySignsMassEditMode {
@@ -19,7 +19,7 @@ namespace TrafficManager.UI.SubTools {
             MainStop = 1,
             YieldMain = 2,
             StopMain = 3,
-            Delete = 4
+            Delete = 4,
         }
 
         private readonly HashSet<ushort> currentPriorityNodeIds;

--- a/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
@@ -1,18 +1,18 @@
 ﻿namespace TrafficManager.UI.SubTools.SpeedLimits {
-    using System;
-    using System.Collections.Generic;
-    using API.Traffic.Data;
-    using ColossalFramework;
     using ColossalFramework.UI;
+    using ColossalFramework;
     using CSUtil.Commons;
     using GenericGameBridge.Service;
-    using Manager.Impl;
-    using State;
-    using Textures;
-    using Traffic;
+    using System.Collections.Generic;
+    using System;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.State;
+    using TrafficManager.Traffic;
+    using TrafficManager.UI.Textures;
+    using TrafficManager.Util.Caching;
+    using TrafficManager.Util;
     using UnityEngine;
-    using Util;
-    using Util.Caching;
 
     public class SpeedLimitsTool : SubTool {
         public const int

--- a/TLM/TLM/UI/SubTools/TimedTrafficLightsTool.cs
+++ b/TLM/TLM/UI/SubTools/TimedTrafficLightsTool.cs
@@ -1,17 +1,17 @@
 namespace TrafficManager.UI.SubTools {
-    using TrafficManager.Util;
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using API.Manager;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
-    using API.TrafficLight;
     using ColossalFramework;
     using CSUtil.Commons;
-    using Manager.Impl;
-    using State;
-    using Textures;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.API.TrafficLight;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.State;
+    using TrafficManager.UI.Textures;
+    using TrafficManager.Util;
     using UnityEngine;
 
     public class TimedTrafficLightsTool : SubTool {

--- a/TLM/TLM/UI/SubTools/ToggleTrafficLightsTool.cs
+++ b/TLM/TLM/UI/SubTools/ToggleTrafficLightsTool.cs
@@ -1,11 +1,11 @@
 ﻿namespace TrafficManager.UI.SubTools {
-    using API.Traffic.Enums;
     using ColossalFramework;
-    using Manager.Impl;
-    using State;
-    using Textures;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.State;
+    using TrafficManager.UI.Textures;
+    using TrafficManager.Util.Caching;
     using UnityEngine;
-    using Util.Caching;
 
     public class ToggleTrafficLightsTool : SubTool {
         /// <summary>

--- a/TLM/TLM/UI/SubTools/VehicleRestrictionsTool.cs
+++ b/TLM/TLM/UI/SubTools/VehicleRestrictionsTool.cs
@@ -1,14 +1,14 @@
 ﻿namespace TrafficManager.UI.SubTools {
-    using System.Collections.Generic;
-    using API.Traffic.Enums;
     using ColossalFramework;
     using GenericGameBridge.Service;
-    using Manager.Impl;
-    using State;
-    using Textures;
-    using Util;
-    using UnityEngine;
     using static Util.SegmentLaneTraverser;
+    using System.Collections.Generic;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.State;
+    using TrafficManager.UI.Textures;
+    using TrafficManager.Util;
+    using UnityEngine;
 
     public class VehicleRestrictionsTool : SubTool {
         private static readonly ExtVehicleType[] RoadVehicleTypes = {

--- a/TLM/TLM/UI/Textures/JunctionUITextures.cs
+++ b/TLM/TLM/UI/Textures/JunctionUITextures.cs
@@ -1,9 +1,9 @@
 namespace TrafficManager.UI.Textures {
     using System;
     using System.Collections.Generic;
-    using State;
+    using TrafficManager.State;
     using UnityEngine;
-    using Util;
+    using TrafficManager.Util;
     using static TextureResources;
 
     /// <summary>

--- a/TLM/TLM/UI/Textures/RoadUITextures.cs
+++ b/TLM/TLM/UI/Textures/RoadUITextures.cs
@@ -1,9 +1,9 @@
 namespace TrafficManager.UI.Textures {
-    using System.Collections.Generic;
-    using API.Traffic.Enums;
-    using UnityEngine;
-    using Util;
     using static TextureResources;
+    using System.Collections.Generic;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Util;
+    using UnityEngine;
 
     /// <summary>
     /// UI Textures for controlling road segments

--- a/TLM/TLM/UI/Textures/SpeedLimitTextures.cs
+++ b/TLM/TLM/UI/Textures/SpeedLimitTextures.cs
@@ -1,12 +1,12 @@
 namespace TrafficManager.UI.Textures {
-    using System;
-    using System.Collections.Generic;
-    using API.Traffic.Data;
-    using State;
-    using SubTools.SpeedLimits;
-    using UnityEngine;
-    using Util;
     using static TextureResources;
+    using System.Collections.Generic;
+    using System;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.State;
+    using TrafficManager.UI.SubTools.SpeedLimits;
+    using TrafficManager.Util;
+    using UnityEngine;
 
     public static class SpeedLimitTextures {
         public static readonly IDictionary<int, Texture2D> TexturesKmph;

--- a/TLM/TLM/UI/Textures/TextureResources.cs
+++ b/TLM/TLM/UI/Textures/TextureResources.cs
@@ -1,9 +1,9 @@
 namespace TrafficManager.UI.Textures {
-    using System;
+    using CSUtil.Commons;
     using System.IO;
     using System.Reflection;
-    using CSUtil.Commons;
-    using State.ConfigData;
+    using System;
+    using TrafficManager.State.ConfigData;
     using UnityEngine;
 
     public static class TextureResources {

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -1,24 +1,24 @@
 namespace TrafficManager.UI {
-    using System;
+    using ColossalFramework.Math;
+    using ColossalFramework.UI;
+    using ColossalFramework;
+    using CSUtil.Commons;
+    using JetBrains.Annotations;
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;
-    using API.Manager;
-    using API.Traffic.Data;
-    using API.Traffic.Enums;
-    using API.Util;
-    using ColossalFramework;
-    using ColossalFramework.Math;
-    using ColossalFramework.UI;
-    using CSUtil.Commons;
-    using JetBrains.Annotations;
-    using Manager.Impl;
-    using State;
-    using State.ConfigData;
-    using MainMenu;
-    using SubTools;
-    using SubTools.SpeedLimits;
-    using Util;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.API.Util;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.State.ConfigData;
+    using TrafficManager.State;
+    using TrafficManager.UI.MainMenu;
+    using TrafficManager.UI.SubTools.SpeedLimits;
+    using TrafficManager.UI.SubTools;
+    using TrafficManager.Util;
     using UnityEngine;
 
     [UsedImplicitly]

--- a/TLM/TLM/UI/UIBase.cs
+++ b/TLM/TLM/UI/UIBase.cs
@@ -1,8 +1,8 @@
 namespace TrafficManager.UI {
-    using System;
     using ColossalFramework.UI;
     using CSUtil.Commons;
-    using UI.MainMenu;
+    using System;
+    using TrafficManager.UI.MainMenu;
     using UnityEngine;
 
     public class UIBase : UICustomControl {

--- a/TLM/TLM/UI/UIMainMenuButton.cs
+++ b/TLM/TLM/UI/UIMainMenuButton.cs
@@ -1,13 +1,13 @@
 namespace TrafficManager.UI {
-    using System;
-    using API.Util;
     using ColossalFramework.UI;
     using CSUtil.Commons;
-    using State;
-    using State.Keybinds;
-    using Textures;
+    using System;
+    using TrafficManager.API.Util;
+    using TrafficManager.State.Keybinds;
+    using TrafficManager.State;
+    using TrafficManager.UI.Textures;
+    using TrafficManager.Util;
     using UnityEngine;
-    using Util;
 
     public class UIMainMenuButton
         : UIButton,

--- a/TLM/TLM/UI/UITransportDemand.cs
+++ b/TLM/TLM/UI/UITransportDemand.cs
@@ -1,7 +1,7 @@
 namespace TrafficManager.UI {
     using ColossalFramework.UI;
     using CSUtil.Commons;
-    using State;
+    using TrafficManager.State;
     using UnityEngine;
 
     public class UITransportDemand : UIPanel {

--- a/TLM/TLM/Util/AutoTimedTrafficLights.cs
+++ b/TLM/TLM/Util/AutoTimedTrafficLights.cs
@@ -1,15 +1,15 @@
 namespace TrafficManager.Util {
-    using TrafficManager.Manager.Impl;
-    using System.Collections.Generic;
     using ColossalFramework;
-    using UnityEngine;
+    using CSUtil.Commons;
     using GenericGameBridge.Service;
-    using API.TrafficLight;
-    using API.TrafficLight.Data;
-    using API.Traffic.Enums;
+    using System.Collections.Generic;
     using TrafficManager.API.Manager;
     using TrafficManager.API.Traffic.Data;
-    using CSUtil.Commons;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.API.TrafficLight.Data;
+    using TrafficManager.API.TrafficLight;
+    using TrafficManager.Manager.Impl;
+    using UnityEngine;
 
     public static class AutoTimedTrafficLights {
         /// <summary>

--- a/TLM/TLM/Util/Caching/CameraTransformValue.cs
+++ b/TLM/TLM/Util/Caching/CameraTransformValue.cs
@@ -1,6 +1,6 @@
 namespace TrafficManager.Util.Caching {
+    using TrafficManager.Util;
     using UnityEngine;
-    using Util;
 
     /// <summary>
     /// Stores transform of the camera, namely position, rotation.

--- a/TLM/TLM/Util/GenericObservable.cs
+++ b/TLM/TLM/Util/GenericObservable.cs
@@ -1,9 +1,9 @@
 ﻿namespace TrafficManager.Util {
-    using System;
+    using CSUtil.Commons;
     using System.Collections.Generic;
     using System.Threading;
-    using API.Util;
-    using CSUtil.Commons;
+    using System;
+    using TrafficManager.API.Util;
 
     public abstract class GenericObservable<T> : IObservable<T> {
         /// <summary>

--- a/TLM/TLM/Util/GenericUnsubscriber.cs
+++ b/TLM/TLM/Util/GenericUnsubscriber.cs
@@ -1,8 +1,8 @@
 ﻿namespace TrafficManager.Util {
-    using System;
     using System.Collections.Generic;
     using System.Threading;
-    using API.Util;
+    using System;
+    using TrafficManager.API.Util;
 
     public class GenericUnsubscriber<T> : IDisposable {
         private readonly List<IObserver<T>> observers_;

--- a/TLM/TLM/Util/ModsCompatibilityChecker.cs
+++ b/TLM/TLM/Util/ModsCompatibilityChecker.cs
@@ -1,17 +1,17 @@
 namespace TrafficManager.Util {
-    using System;
+    using ColossalFramework.Plugins;
+    using ColossalFramework.UI;
+    using ColossalFramework;
+    using CSUtil.Commons;
+    using ICities;
+    using static ColossalFramework.Plugins.PluginManager;
     using System.Collections.Generic;
     using System.IO;
     using System.Reflection;
-    using ColossalFramework;
-    using ColossalFramework.Plugins;
-    using ColossalFramework.UI;
-    using CSUtil.Commons;
-    using ICities;
-    using State;
-    using UI;
+    using System;
+    using TrafficManager.State;
+    using TrafficManager.UI;
     using UnityEngine;
-    using static ColossalFramework.Plugins.PluginManager;
 
     public class ModsCompatibilityChecker {
         // Game always uses ulong.MaxValue to depict local mods

--- a/TLM/TLM/Util/RoundaboutMassEdit.cs
+++ b/TLM/TLM/Util/RoundaboutMassEdit.cs
@@ -1,16 +1,16 @@
 namespace TrafficManager.Util {
-    using System;
-    using System.Collections.Generic;
-    using UnityEngine;
-    using API.Traffic.Data;
     using CSUtil.Commons;
-    using TrafficManager.Manager.Impl;
-    using API.Traffic.Enums;
     using GenericGameBridge.Service;
-    using State;
-    using static Util.Shortcuts;
     using static Manager.Impl.LaneArrowManager.SeparateTurningLanes;
     using static UI.SubTools.LaneConnectorTool;
+    using static Util.Shortcuts;
+    using System.Collections.Generic;
+    using System;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.State;
+    using UnityEngine;
 
     public class RoundaboutMassEdit {
         public static RoundaboutMassEdit Instance = new RoundaboutMassEdit();

--- a/TLM/TLM/Util/SegmentTraverser.cs
+++ b/TLM/TLM/Util/SegmentTraverser.cs
@@ -1,10 +1,10 @@
 namespace TrafficManager.Util {
-    using System;
-    using System.Collections.Generic;
-    using API.Manager;
-    using API.Traffic.Data;
     using ColossalFramework;
     using CSUtil.Commons;
+    using System.Collections.Generic;
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Data;
 
     public class SegmentTraverser {
         [Flags]

--- a/TLM/TMPE.API/Geometry/ISegmentEndGeometry.cs
+++ b/TLM/TMPE.API/Geometry/ISegmentEndGeometry.cs
@@ -1,7 +1,7 @@
 ﻿namespace TrafficManager.API.Geometry {
     using CSUtil.Commons;
-    using Traffic;
-    using Traffic.Enums;
+    using TrafficManager.API.Traffic;
+    using TrafficManager.API.Traffic.Enums;
 
     public interface ISegmentEndGeometry : ISegmentEndId {
         /// <summary>

--- a/TLM/TMPE.API/Geometry/ISegmentGeometry.cs
+++ b/TLM/TMPE.API/Geometry/ISegmentGeometry.cs
@@ -1,7 +1,7 @@
 ﻿namespace TrafficManager.Geometry {
-    using API.Geometry;
-    using API.Traffic.Enums;
     using JetBrains.Annotations;
+    using TrafficManager.API.Geometry;
+    using TrafficManager.API.Traffic.Enums;
 
     // Not used
     [UsedImplicitly]

--- a/TLM/TMPE.API/Geometry/SegmentEndReplacement.cs
+++ b/TLM/TMPE.API/Geometry/SegmentEndReplacement.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrafficManager.API.Geometry {
     using System;
-    using Traffic;
+    using TrafficManager.API.Traffic;
 
     public struct SegmentEndReplacement {
         public ISegmentEndId oldSegmentEndId;

--- a/TLM/TMPE.API/Manager/IAdvancedParkingManager.cs
+++ b/TLM/TMPE.API/Manager/IAdvancedParkingManager.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrafficManager.API.Manager {
-    using Traffic.Data;
-    using Traffic.Enums;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
     using UnityEngine;
 
     public interface IAdvancedParkingManager : IFeatureManager {

--- a/TLM/TMPE.API/Manager/ICustomSegmentLightsManager.cs
+++ b/TLM/TMPE.API/Manager/ICustomSegmentLightsManager.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrafficManager.API.Manager {
-    using Traffic.Enums;
-    using TrafficLight;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.API.TrafficLight;
 
     public interface ICustomSegmentLightsManager {
         // TODO documentation

--- a/TLM/TMPE.API/Manager/IExtBuildingManager.cs
+++ b/TLM/TMPE.API/Manager/IExtBuildingManager.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.API.Manager {
-    using Traffic.Data;
+    using TrafficManager.API.Traffic.Data;
     using UnityEngine;
 
     public interface IExtBuildingManager {

--- a/TLM/TMPE.API/Manager/IExtCitizenInstanceManager.cs
+++ b/TLM/TMPE.API/Manager/IExtCitizenInstanceManager.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrafficManager.API.Manager {
     using System;
-    using Traffic.Data;
+    using TrafficManager.API.Traffic.Data;
     using UnityEngine;
 
     public interface IExtCitizenInstanceManager {

--- a/TLM/TMPE.API/Manager/IExtCitizenManager.cs
+++ b/TLM/TMPE.API/Manager/IExtCitizenManager.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.API.Manager {
-    using Traffic.Data;
+    using TrafficManager.API.Traffic.Data;
 
     public interface IExtCitizenManager {
         // TODO define me!

--- a/TLM/TMPE.API/Manager/IExtNodeManager.cs
+++ b/TLM/TMPE.API/Manager/IExtNodeManager.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.API.Manager {
-    using Traffic.Data;
+    using TrafficManager.API.Traffic.Data;
 
     public interface IExtNodeManager {
         /// <summary>

--- a/TLM/TMPE.API/Manager/IExtSegmentEndManager.cs
+++ b/TLM/TMPE.API/Manager/IExtSegmentEndManager.cs
@@ -1,6 +1,6 @@
 namespace TrafficManager.API.Manager {
     using CSUtil.Commons;
-    using Traffic.Data;
+    using TrafficManager.API.Traffic.Data;
 
     public interface IExtSegmentEndManager {
         /// <summary>

--- a/TLM/TMPE.API/Manager/IExtSegmentManager.cs
+++ b/TLM/TMPE.API/Manager/IExtSegmentManager.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.API.Manager {
-    using Traffic.Data;
+    using TrafficManager.API.Traffic.Data;
 
     public interface IExtSegmentManager {
         /// <summary>

--- a/TLM/TMPE.API/Manager/IExtVehicleManager.cs
+++ b/TLM/TMPE.API/Manager/IExtVehicleManager.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrafficManager.API.Manager {
-    using Traffic.Data;
-    using Traffic.Enums;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
 
     public interface IExtVehicleManager {
         /// <summary>

--- a/TLM/TMPE.API/Manager/IGeometryManager.cs
+++ b/TLM/TMPE.API/Manager/IGeometryManager.cs
@@ -1,8 +1,8 @@
 ﻿namespace TrafficManager.API.Manager {
     using System;
-    using Geometry;
-    using Traffic.Data;
-    using Util;
+    using TrafficManager.API.Geometry;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Util;
 
     public struct GeometryUpdate {
         public ExtSegment? segment { get; private set; }

--- a/TLM/TMPE.API/Manager/IRoutingManager.cs
+++ b/TLM/TMPE.API/Manager/IRoutingManager.cs
@@ -1,7 +1,7 @@
 ﻿namespace TrafficManager.API.Manager {
     using System;
     using CSUtil.Commons;
-    using Traffic.Enums;
+    using TrafficManager.API.Traffic.Enums;
 
     public struct SegmentRoutingData {
         public bool startNodeOutgoingOneWay;

--- a/TLM/TMPE.API/Manager/ISegmentEndManager.cs
+++ b/TLM/TMPE.API/Manager/ISegmentEndManager.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrafficManager.API.Manager {
     using System;
-    using Traffic;
+    using TrafficManager.API.Traffic;
 
     [Obsolete("should be removed when implementing issue #240")]
     public interface ISegmentEndManager {

--- a/TLM/TMPE.API/Manager/ITrafficLightManager.cs
+++ b/TLM/TMPE.API/Manager/ITrafficLightManager.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.API.Manager {
-    using Traffic.Enums;
+    using TrafficManager.API.Traffic.Enums;
 
     public interface ITrafficLightManager {
         // TODO documentation

--- a/TLM/TMPE.API/Manager/ITrafficLightSimulationManager.cs
+++ b/TLM/TMPE.API/Manager/ITrafficLightSimulationManager.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrafficManager.API.Manager {
     using System.Collections.Generic;
-    using TrafficLight.Data;
+    using TrafficManager.API.TrafficLight.Data;
 
     public interface ITrafficLightSimulationManager {
         // TODO documentation

--- a/TLM/TMPE.API/Manager/ITrafficMeasurementManager.cs
+++ b/TLM/TMPE.API/Manager/ITrafficMeasurementManager.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.API.Manager {
-    using Traffic.Data;
+    using TrafficManager.API.Traffic.Data;
 
     public interface ITrafficMeasurementManager {
         // TODO define me!

--- a/TLM/TMPE.API/Manager/ITrafficPriorityManager.cs
+++ b/TLM/TMPE.API/Manager/ITrafficPriorityManager.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrafficManager.API.Manager {
-    using Traffic.Data;
-    using Traffic.Enums;
+    using TrafficManager.API.Traffic.Data;
+    using TrafficManager.API.Traffic.Enums;
 
     public interface ITrafficPriorityManager {
         // TODO define me!

--- a/TLM/TMPE.API/Manager/ITurnOnRedManager.cs
+++ b/TLM/TMPE.API/Manager/ITurnOnRedManager.cs
@@ -1,5 +1,5 @@
 namespace TrafficManager.API.Manager {
-    using Traffic.Data;
+    using TrafficManager.API.Traffic.Data;
 
     public interface ITurnOnRedManager {
         TurnOnRedSegments[] TurnOnRedSegments { get; }

--- a/TLM/TMPE.API/Manager/IVehicleBehaviorManager.cs
+++ b/TLM/TMPE.API/Manager/IVehicleBehaviorManager.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.API.Manager {
-    using Traffic.Data;
+    using TrafficManager.API.Traffic.Data;
     using UnityEngine;
 
     public interface IVehicleBehaviorManager {

--- a/TLM/TMPE.API/Manager/IVehicleRestrictionsManager.cs
+++ b/TLM/TMPE.API/Manager/IVehicleRestrictionsManager.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrafficManager.API.Manager {
     using System.Collections.Generic;
-    using Traffic.Enums;
+    using TrafficManager.API.Traffic.Enums;
 
     public interface IVehicleRestrictionsManager {
         // TODO documentation

--- a/TLM/TMPE.API/Traffic/Data/ExtCitizen.cs
+++ b/TLM/TMPE.API/Traffic/Data/ExtCitizen.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.API.Traffic.Data {
-    using Enums;
+    using TrafficManager.API.Traffic.Enums;
 
     public struct ExtCitizen {
         public uint citizenId;

--- a/TLM/TMPE.API/Traffic/Data/ExtCitizenInstance.cs
+++ b/TLM/TMPE.API/Traffic/Data/ExtCitizenInstance.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrafficManager.API.Traffic.Data {
     using System;
-    using Enums;
+    using TrafficManager.API.Traffic.Enums;
 
     public struct ExtCitizenInstance {
         public ushort instanceId;

--- a/TLM/TMPE.API/Traffic/Data/ExtVehicle.cs
+++ b/TLM/TMPE.API/Traffic/Data/ExtVehicle.cs
@@ -1,6 +1,6 @@
 namespace TrafficManager.API.Traffic.Data {
     using System;
-    using Enums;
+    using TrafficManager.API.Traffic.Enums;
 
     public struct ExtVehicle {
         public ushort vehicleId;

--- a/TLM/TMPE.API/Traffic/Data/PathCreationArgs.cs
+++ b/TLM/TMPE.API/Traffic/Data/PathCreationArgs.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.API.Traffic.Data {
-    using Enums;
+    using TrafficManager.API.Traffic.Enums;
 
     public struct PathCreationArgs {
         /// <summary>

--- a/TLM/TMPE.API/Traffic/Data/PathUnitQueueItem.cs
+++ b/TLM/TMPE.API/Traffic/Data/PathUnitQueueItem.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrafficManager.API.Traffic.Data {
     using System;
-    using Enums;
+    using TrafficManager.API.Traffic.Enums;
 
     public struct PathUnitQueueItem {
         public uint nextPathUnitId; // access requires acquisition of CustomPathFind.QueueLock

--- a/TLM/TMPE.API/Traffic/Data/PrioritySegment.cs
+++ b/TLM/TMPE.API/Traffic/Data/PrioritySegment.cs
@@ -1,6 +1,6 @@
 namespace TrafficManager.API.Traffic.Data {
-    using Enums;
     using JetBrains.Annotations;
+    using TrafficManager.API.Traffic.Enums;
 
     /// <summary>
     /// A priority segment specifies the priority signs that are present at each end of a certain segment.

--- a/TLM/TMPE.API/TrafficLight/Data/TrafficLightSimulation.cs
+++ b/TLM/TMPE.API/TrafficLight/Data/TrafficLightSimulation.cs
@@ -1,8 +1,8 @@
 namespace TrafficManager.API.TrafficLight.Data {
-    using System;
     using CSUtil.Commons;
-    using Traffic.Enums;
-    using TrafficLight;
+    using System;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.API.TrafficLight;
 
     public struct TrafficLightSimulation {
         /// <summary>

--- a/TLM/TMPE.API/TrafficLight/ICustomSegmentLight.cs
+++ b/TLM/TMPE.API/TrafficLight/ICustomSegmentLight.cs
@@ -1,7 +1,7 @@
 ﻿namespace TrafficManager.API.TrafficLight {
     using System;
     using CSUtil.Commons;
-    using Traffic.Enums;
+    using TrafficManager.API.Traffic.Enums;
 
     public interface ICustomSegmentLight : ICloneable {
         // TODO documentation

--- a/TLM/TMPE.API/TrafficLight/ICustomSegmentLights.cs
+++ b/TLM/TMPE.API/TrafficLight/ICustomSegmentLights.cs
@@ -1,9 +1,9 @@
 ﻿namespace TrafficManager.API.TrafficLight {
     using System;
     using System.Collections.Generic;
-    using Manager;
-    using Traffic;
-    using Traffic.Enums;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic;
+    using TrafficManager.API.Traffic.Enums;
 
     public interface ICustomSegmentLights : ICloneable, ISegmentEndId {
         // TODO documentation

--- a/TLM/TMPE.API/TrafficLight/ITimedTrafficLights.cs
+++ b/TLM/TMPE.API/TrafficLight/ITimedTrafficLights.cs
@@ -1,7 +1,7 @@
 ﻿namespace TrafficManager.API.TrafficLight {
     using System.Collections.Generic;
     using CSUtil.Commons;
-    using Traffic.Enums;
+    using TrafficManager.API.Traffic.Enums;
 
     public interface ITimedTrafficLights {
         IDictionary<ushort, IDictionary<ushort, ArrowDirection>> Directions { get; }

--- a/TLM/TMPE.API/TrafficLight/ITimedTrafficLightsStep.cs
+++ b/TLM/TMPE.API/TrafficLight/ITimedTrafficLightsStep.cs
@@ -1,7 +1,7 @@
 ﻿namespace TrafficManager.API.TrafficLight {
     using System.Collections.Generic;
-    using Manager;
-    using Traffic.Enums;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Traffic.Enums;
 
     public interface ITimedTrafficLightsStep : ICustomSegmentLightsManager {
         // TODO documentation

--- a/TLM/TMPE.GenericGameBridge/Factory/IServiceFactory.cs
+++ b/TLM/TMPE.GenericGameBridge/Factory/IServiceFactory.cs
@@ -1,5 +1,5 @@
 ﻿namespace GenericGameBridge.Factory {
-    using Service;
+    using GenericGameBridge.Service;
 
     public interface IServiceFactory {
         IBuildingService BuildingService { get; }


### PR DESCRIPTION
Fighting minor warnings as a major source of IDE performance problems and for the peace of mind.
This PR replaces shortened imports with fully qualified imports making Roslyn more happy.
Disable Rider warning on "Redundant qualifier" because fully qualified is good.

* Does not remove or add imports
* Does not change functionality anywhere, unless some ambiguous import was guessed wrong
* Might affect some special debug-style builds