### PR TITLE
Fixed junction manger OnLevelUnloading()

### DIFF
--- a/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
@@ -886,7 +886,7 @@ namespace TrafficManager.Manager.Impl {
             base.OnLevelUnloading();
 
             for (int i = 0; i < segmentFlags_.Length; ++i) {
-                segmentFlags_[i].Reset(startNode:null, resetDefaults: true);
+                segmentFlags_[i].Reset(startNode: null, resetDefaults: true);
             }
 
             for (int i = 0; i < invalidSegmentFlags.Length; ++i) {

--- a/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
@@ -886,11 +886,11 @@ namespace TrafficManager.Manager.Impl {
             base.OnLevelUnloading();
 
             for (int i = 0; i < segmentFlags_.Length; ++i) {
-                segmentFlags_[i].Reset(true);
+                segmentFlags_[i].Reset(startNode:null, resetDefaults: true);
             }
 
             for (int i = 0; i < invalidSegmentFlags.Length; ++i) {
-                invalidSegmentFlags[i].Reset(true);
+                invalidSegmentFlags[i].Reset(startNode: null, resetDefaults: true);
             }
         }
 


### PR DESCRIPTION
fixes #636 

Fixed junction manger OnLevelUnloading() is now fixed to reset both ends of the segment.