### PR TITLE
delete junction restrictions

### DIFF
--- a/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
@@ -793,38 +793,39 @@ namespace TrafficManager.Manager.Impl {
             ret |= SetUturnAllowed(segmentId, startNode, TernaryBool.Undefined);
             return ret;
         }
+
         private void SetSegmentEndFlags(ushort segmentId, bool startNode, SegmentEndFlags flags) {
             if (flags.uturnAllowed != TernaryBool.Undefined) {
-                SetUturnAllowed(segmentId, startNode, flags.uturnAllowed);
+                SetUturnAllowed(segmentId, startNode, flags.IsUturnAllowed());
             }
 
             if (flags.nearTurnOnRedAllowed != TernaryBool.Undefined) {
-                SetNearTurnOnRedAllowed(segmentId, startNode, flags.nearTurnOnRedAllowed);
+                SetNearTurnOnRedAllowed(segmentId, startNode, flags.IsNearTurnOnRedAllowed());
             }
 
             if (flags.nearTurnOnRedAllowed != TernaryBool.Undefined) {
-                SetFarTurnOnRedAllowed(segmentId, startNode, flags.nearTurnOnRedAllowed);
+                SetFarTurnOnRedAllowed(segmentId, startNode, flags.IsNearTurnOnRedAllowed());
             }
 
             if (flags.straightLaneChangingAllowed != TernaryBool.Undefined) {
                 SetLaneChangingAllowedWhenGoingStraight(
                     segmentId,
                     startNode,
-                    flags.straightLaneChangingAllowed);
+                    flags.IsLaneChangingAllowedWhenGoingStraight());
             }
 
             if (flags.enterWhenBlockedAllowed != TernaryBool.Undefined) {
                 SetEnteringBlockedJunctionAllowed(
                     segmentId,
                     startNode,
-                    flags.enterWhenBlockedAllowed);
+                    flags.IsEnteringBlockedJunctionAllowed());
             }
 
             if (flags.pedestrianCrossingAllowed != TernaryBool.Undefined) {
                 SetPedestrianCrossingAllowed(
                     segmentId,
                     startNode,
-                    flags.pedestrianCrossingAllowed);
+                    flags.IsPedestrianCrossingAllowed());
             }
         }
 

--- a/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
@@ -835,7 +835,7 @@ namespace TrafficManager.Manager.Impl {
             return ref Shortcuts.GetNode(nodeId);
         }
 
-        #region Set<Traffic Rule>AllowedTernaryBool 
+        #region Set<Traffic Rule>Allowed: TernaryBool 
 
         public bool SetUturnAllowed(ushort segmentId, bool startNode, TernaryBool value) {
             if (!Services.NetService.IsSegmentValid(segmentId)) {

--- a/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
@@ -12,6 +12,9 @@ namespace TrafficManager.Manager.Impl {
     using TrafficManager.State.ConfigData;
     using TrafficManager.State;
     using TrafficManager.Traffic;
+    using static TrafficManager.Util.Shortcuts;
+    using static CSUtil.Commons.TernaryBoolUtil;
+    using TrafficManager.Util;
 
     public class JunctionRestrictionsManager
         : AbstractGeometryObservingManager,
@@ -743,47 +746,109 @@ namespace TrafficManager.Manager.Impl {
                 !IsPedestrianCrossingAllowed(segmentId, startNode));
         }
 
+        public bool SetUturnAllowed(ushort segmentId, bool startNode, bool value) {
+            return SetUturnAllowed(segmentId, startNode, ToTernaryBool(value));
+        }
+
+        public bool SetNearTurnOnRedAllowed(ushort segmentId, bool startNode, bool value) {
+            return SetNearTurnOnRedAllowed(segmentId, startNode, ToTernaryBool(value));
+        }
+
+        public bool SetFarTurnOnRedAllowed(ushort segmentId, bool startNode, bool value) {
+            return SetFarTurnOnRedAllowed(segmentId, startNode, ToTernaryBool(value));
+        }
+
+        public bool SetTurnOnRedAllowed(bool near, ushort segmentId, bool startNode, bool value) {
+            return SetTurnOnRedAllowed(near, segmentId, startNode, ToTernaryBool(value));
+        }
+
+        public bool SetLaneChangingAllowedWhenGoingStraight(ushort segmentId, bool startNode, bool value) {
+            return SetLaneChangingAllowedWhenGoingStraight(
+                segmentId,
+                startNode,
+                ToTernaryBool(value));
+        }
+
+        public bool SetEnteringBlockedJunctionAllowed(ushort segmentId, bool startNode, bool value) {
+            return SetEnteringBlockedJunctionAllowed(
+                segmentId,
+                startNode,
+                ToTernaryBool(value));
+        }
+
+        public bool SetPedestrianCrossingAllowed(ushort segmentId, bool startNode, bool value) {
+            return SetPedestrianCrossingAllowed(
+                segmentId,
+                startNode,
+                ToTernaryBool(value));
+        }
+
+        public bool ClearSegmentEnd(ushort segmentId, bool startNode) {
+            bool ret = true;
+            ret |= SetPedestrianCrossingAllowed(segmentId, startNode, TernaryBool.Undefined);
+            ret |= SetEnteringBlockedJunctionAllowed(segmentId, startNode, TernaryBool.Undefined);
+            ret |= SetLaneChangingAllowedWhenGoingStraight(segmentId, startNode, TernaryBool.Undefined);
+            ret |= SetFarTurnOnRedAllowed(segmentId, startNode, TernaryBool.Undefined);
+            ret |= SetNearTurnOnRedAllowed(segmentId, startNode, TernaryBool.Undefined);
+            ret |= SetUturnAllowed(segmentId, startNode, TernaryBool.Undefined);
+            return ret;
+        }
         private void SetSegmentEndFlags(ushort segmentId, bool startNode, SegmentEndFlags flags) {
             if (flags.uturnAllowed != TernaryBool.Undefined) {
-                SetUturnAllowed(segmentId, startNode, flags.IsUturnAllowed());
+                SetUturnAllowed(segmentId, startNode, flags.uturnAllowed);
             }
 
             if (flags.nearTurnOnRedAllowed != TernaryBool.Undefined) {
-                SetNearTurnOnRedAllowed(segmentId, startNode, flags.IsNearTurnOnRedAllowed());
+                SetNearTurnOnRedAllowed(segmentId, startNode, flags.nearTurnOnRedAllowed);
             }
 
             if (flags.nearTurnOnRedAllowed != TernaryBool.Undefined) {
-                SetFarTurnOnRedAllowed(segmentId, startNode, flags.IsFarTurnOnRedAllowed());
+                SetFarTurnOnRedAllowed(segmentId, startNode, flags.nearTurnOnRedAllowed);
             }
 
             if (flags.straightLaneChangingAllowed != TernaryBool.Undefined) {
                 SetLaneChangingAllowedWhenGoingStraight(
                     segmentId,
                     startNode,
-                    flags.IsLaneChangingAllowedWhenGoingStraight());
+                    flags.straightLaneChangingAllowed);
             }
 
             if (flags.enterWhenBlockedAllowed != TernaryBool.Undefined) {
                 SetEnteringBlockedJunctionAllowed(
                     segmentId,
                     startNode,
-                    flags.IsEnteringBlockedJunctionAllowed());
+                    flags.enterWhenBlockedAllowed);
             }
 
             if (flags.pedestrianCrossingAllowed != TernaryBool.Undefined) {
                 SetPedestrianCrossingAllowed(
                     segmentId,
                     startNode,
-                    flags.IsPedestrianCrossingAllowed());
+                    flags.pedestrianCrossingAllowed);
             }
         }
 
-        public bool SetUturnAllowed(ushort segmentId, bool startNode, bool value) {
+
+        private static ref NetNode GetNode(ushort segmentId, bool startNode) {
+            ref NetSegment segment = ref GetSeg(segmentId);
+            ushort nodeId = startNode ? segment.m_startNode : segment.m_endNode;
+            return ref Shortcuts.GetNode(nodeId);
+        }
+
+        #region Set<Traffic Rule>AllowedTernaryBool 
+
+        public bool SetUturnAllowed(ushort segmentId, bool startNode, TernaryBool value) {
             if (!Services.NetService.IsSegmentValid(segmentId)) {
                 return false;
             }
+            if(GetUturnAllowed(segmentId,startNode) == value) {
+                return true;
+            }
+            if(!IsUturnAllowedConfigurable(segmentId,startNode, ref GetNode(segmentId, startNode))) {
+                return false;
+            }
 
-            if (!value && Constants.ManagerFactory.LaneConnectionManager.HasUturnConnections(
+            if (value == TernaryBool.False && Constants.ManagerFactory.LaneConnectionManager.HasUturnConnections(
                     segmentId,
                     startNode)) {
                 return false;
@@ -798,16 +863,28 @@ namespace TrafficManager.Manager.Impl {
             return true;
         }
 
-        public bool SetNearTurnOnRedAllowed(ushort segmentId, bool startNode, bool value) {
+        public bool SetNearTurnOnRedAllowed(ushort segmentId, bool startNode, TernaryBool value) {
             return SetTurnOnRedAllowed(true, segmentId, startNode, value);
         }
 
-        public bool SetFarTurnOnRedAllowed(ushort segmentId, bool startNode, bool value) {
+        public bool SetFarTurnOnRedAllowed(ushort segmentId, bool startNode, TernaryBool value) {
             return SetTurnOnRedAllowed(false, segmentId, startNode, value);
         }
 
-        public bool SetTurnOnRedAllowed(bool near, ushort segmentId, bool startNode, bool value) {
+        public bool SetTurnOnRedAllowed(bool near, ushort segmentId, bool startNode, TernaryBool value) {
             if (!Services.NetService.IsSegmentValid(segmentId)) {
+                return false;
+            }
+            if (GetTurnOnRedAllowed(near, segmentId, startNode) == value) {
+                return true;
+            }
+            if (!IsTurnOnRedAllowedConfigurable(near, segmentId, startNode, ref GetNode(segmentId, startNode))) {
+                return false;
+            }
+
+            if (value == TernaryBool.False && Constants.ManagerFactory.LaneConnectionManager.HasUturnConnections(
+                    segmentId,
+                    startNode)) {
                 return false;
             }
 
@@ -823,8 +900,14 @@ namespace TrafficManager.Manager.Impl {
         public bool SetLaneChangingAllowedWhenGoingStraight(
             ushort segmentId,
             bool startNode,
-            bool value) {
+            TernaryBool value) {
             if (!Services.NetService.IsSegmentValid(segmentId)) {
+                return false;
+            }
+            if (GetLaneChangingAllowedWhenGoingStraight(segmentId, startNode) == value) {
+                return true;
+            }
+            if (!IsLaneChangingAllowedWhenGoingStraightConfigurable(segmentId, startNode, ref GetNode(segmentId, startNode))) {
                 return false;
             }
 
@@ -837,9 +920,14 @@ namespace TrafficManager.Manager.Impl {
             return true;
         }
 
-        public bool
-            SetEnteringBlockedJunctionAllowed(ushort segmentId, bool startNode, bool value) {
+        public bool SetEnteringBlockedJunctionAllowed(ushort segmentId, bool startNode, TernaryBool value) {
             if (!Services.NetService.IsSegmentValid(segmentId)) {
+                return false;
+            }
+            if (GetEnteringBlockedJunctionAllowed(segmentId, startNode) == value) {
+                return true;
+            }
+            if (!IsEnteringBlockedJunctionAllowedConfigurable(segmentId, startNode, ref GetNode(segmentId, startNode))) {
                 return false;
             }
 
@@ -854,10 +942,17 @@ namespace TrafficManager.Manager.Impl {
             return true;
         }
 
-        public bool SetPedestrianCrossingAllowed(ushort segmentId, bool startNode, bool value) {
+        public bool SetPedestrianCrossingAllowed(ushort segmentId, bool startNode, TernaryBool value) {
             if (!Services.NetService.IsSegmentValid(segmentId)) {
                 return false;
             }
+            if(GetPedestrianCrossingAllowed(segmentId, startNode) == value) {
+                return true;
+            }
+            if(!IsPedestrianCrossingAllowedConfigurable(segmentId, startNode, ref GetNode(segmentId, startNode))) {
+                return false;
+            }
+
 
             segmentFlags_[segmentId].SetPedestrianCrossingAllowed(startNode, value);
             OnSegmentChange(
@@ -867,6 +962,8 @@ namespace TrafficManager.Manager.Impl {
                 true);
             return true;
         }
+
+#endregion
 
         private void OnSegmentChange(ushort segmentId,
                                      bool startNode,

--- a/TLM/TLM/State/Keybinds/KeybindSetting.cs
+++ b/TLM/TLM/State/Keybinds/KeybindSetting.cs
@@ -113,23 +113,8 @@ namespace TrafficManager.State.Keybinds {
         public bool KeyDown(Event e) {
             bool value = Key.IsPressed(e);
             bool ret = value && !prev_value;
-            if (ret) {
-                prev_value = value; //consume
-            }
-            return ret;
-        }
-
-        /// <summary>
-        /// Determines when user first releases the key. the event is consumed first time
-        /// this function is called.
-        /// </summary>
-        /// <param name="e"></param>
-        /// <returns>true once when user releases the key.</returns>
-        public bool KeyUp(Event e) {
-            bool value = Key.IsPressed(e);
-            bool ret = !value && prev_value;
-            if (ret) {
-                prev_value = value; //consume
+            if (ret || !value) {
+                prev_value = value; 
             }
             return ret;
         }

--- a/TLM/TLM/State/Keybinds/KeybindSetting.cs
+++ b/TLM/TLM/State/Keybinds/KeybindSetting.cs
@@ -95,9 +95,43 @@ namespace TrafficManager.State.Keybinds {
             return result + Keybind.ToLocalizedString(AlternateKey);
         }
 
+        /// <param name="e"></param>
+        /// <returns>true for as long as user holds the key</returns>
         public bool IsPressed(Event e) {
             return Key.IsPressed(e)
                    || (AlternateKey != null && AlternateKey.IsPressed(e));
+        }
+
+        private bool prev_value = false;
+
+        /// <summary>
+        /// Determines when user first presses the key. the event is consumed first time
+        /// this function is called.
+        /// </summary>
+        /// <param name="e"></param>
+        /// <returns>true once when user presses the key.</returns>
+        public bool KeyDown(Event e) {
+            bool value = Key.IsPressed(e);
+            bool ret = value && !prev_value;
+            if (ret) {
+                prev_value = value; //consume
+            }
+            return ret;
+        }
+
+        /// <summary>
+        /// Determines when user first releases the key. the event is consumed first time
+        /// this function is called.
+        /// </summary>
+        /// <param name="e"></param>
+        /// <returns>true once when user releases the key.</returns>
+        public bool KeyUp(Event e) {
+            bool value = Key.IsPressed(e);
+            bool ret = !value && prev_value;
+            if (ret) {
+                prev_value = value; //consume
+            }
+            return ret;
         }
 
         /// <summary>

--- a/TLM/TLM/UI/SubTools/JunctionRestrictionsTool.cs
+++ b/TLM/TLM/UI/SubTools/JunctionRestrictionsTool.cs
@@ -21,7 +21,6 @@ namespace TrafficManager.UI.SubTools {
             currentRestrictedNodeIds = new HashSet<ushort>();
         }
 
-        private bool prev_deletePressed = false;
         public override void OnToolGUI(Event e) {
             // if (SelectedNodeId != 0) {
             //        overlayHandleHovered = false;
@@ -29,10 +28,8 @@ namespace TrafficManager.UI.SubTools {
             // ShowSigns(false);
 
             // handle delete
-            bool deletePressed = KeybindSettingsBase.LaneConnectorDelete.IsPressed(e);
-            bool deleteDown = !prev_deletePressed && deletePressed;
-            prev_deletePressed = deletePressed;
-            if (deleteDown) {
+            if (KeybindSettingsBase.LaneConnectorDelete.KeyDown(e)) {
+                // TODO: #568 provide unified delete key for all managers.
                 bool startNode = (bool)netService.IsStartNode(HoveredSegmentId, HoveredNodeId);
                 JunctionRestrictionsManager.Instance.ClearSegmentEnd(HoveredSegmentId, startNode);
             }

--- a/TLM/TLM/UI/SubTools/JunctionRestrictionsTool.cs
+++ b/TLM/TLM/UI/SubTools/JunctionRestrictionsTool.cs
@@ -8,6 +8,8 @@ namespace TrafficManager.UI.SubTools {
     using TrafficManager.State;
     using TrafficManager.UI.Textures;
     using UnityEngine;
+    using TrafficManager.State.Keybinds;
+    using static TrafficManager.Util.Shortcuts;
 
     public class JunctionRestrictionsTool : SubTool {
         private readonly HashSet<ushort> currentRestrictedNodeIds;
@@ -19,11 +21,21 @@ namespace TrafficManager.UI.SubTools {
             currentRestrictedNodeIds = new HashSet<ushort>();
         }
 
+        private bool prev_deletePressed = false;
         public override void OnToolGUI(Event e) {
             // if (SelectedNodeId != 0) {
             //        overlayHandleHovered = false;
             // }
             // ShowSigns(false);
+
+            // handle delete
+            bool deletePressed = KeybindSettingsBase.LaneConnectorDelete.IsPressed(e);
+            bool deleteDown = !prev_deletePressed && deletePressed;
+            prev_deletePressed = deletePressed;
+            if (deleteDown) {
+                bool startNode = (bool)netService.IsStartNode(HoveredSegmentId, HoveredNodeId);
+                JunctionRestrictionsManager.Instance.ClearSegmentEnd(HoveredSegmentId, startNode);
+            }
         }
 
         public override void RenderInfoOverlay(RenderManager.CameraInfo cameraInfo) { }

--- a/TLM/TLM/UI/SubTools/JunctionRestrictionsTool.cs
+++ b/TLM/TLM/UI/SubTools/JunctionRestrictionsTool.cs
@@ -29,9 +29,14 @@ namespace TrafficManager.UI.SubTools {
 
             // handle delete
             if (KeybindSettingsBase.LaneConnectorDelete.KeyDown(e)) {
-                // TODO: #568 provide unified delete key for all managers.
-                bool startNode = (bool)netService.IsStartNode(HoveredSegmentId, HoveredNodeId);
-                JunctionRestrictionsManager.Instance.ClearSegmentEnd(HoveredSegmentId, startNode);
+                netService.IterateNodeSegments(
+                    SelectedNodeId,
+                    (ushort segmmentId, ref NetSegment segment) => {
+                        // TODO: #568 provide unified delete key for all managers.
+                        bool startNode = (bool)netService.IsStartNode(segmmentId, SelectedNodeId);
+                        JunctionRestrictionsManager.Instance.ClearSegmentEnd(segmmentId, startNode);
+                        return true;
+                    });
             }
         }
 

--- a/TLM/TMPE.API/Manager/IJunctionRestrictionsManager.cs
+++ b/TLM/TMPE.API/Manager/IJunctionRestrictionsManager.cs
@@ -310,7 +310,7 @@ namespace TrafficManager.API.Manager {
         /// <param name="startNode">at start node?</param>
         /// <returns> <c>true</c> on success.
         /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
-        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// On failure (including when traffic rule is not configurable) returns <c>false</c>
         /// </returns>
         bool ToggleUturnAllowed(ushort segmentId, bool startNode);
 
@@ -321,7 +321,7 @@ namespace TrafficManager.API.Manager {
         /// <param name="startNode">at start node?</param>
         /// <returns> <c>true</c> on success.
         /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
-        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// On failure (including when traffic rule is not configurable) returns <c>false</c>
         /// </returns>
         bool ToggleNearTurnOnRedAllowed(ushort segmentId, bool startNode);
 
@@ -332,7 +332,7 @@ namespace TrafficManager.API.Manager {
         /// <param name="startNode">at start node?</param>
         /// <returns> <c>true</c> on success.
         /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
-        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// On failure (including when traffic rule is not configurable) returns <c>false</c>
         /// </returns>
         bool ToggleFarTurnOnRedAllowed(ushort segmentId, bool startNode);
 
@@ -344,7 +344,7 @@ namespace TrafficManager.API.Manager {
         /// <param name="startNode">at start node?</param>
         /// <returns> <c>true</c> on success.
         /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
-        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// On failure (including when traffic rule is not configurable) returns <c>false</c>
         /// </returns>
         bool ToggleTurnOnRedAllowed(bool near, ushort segmentId, bool startNode);
 
@@ -355,7 +355,7 @@ namespace TrafficManager.API.Manager {
         /// <param name="startNode">at start node?</param>
         /// <returns> <c>true</c> on success.
         /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
-        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// On failure (including when traffic rule is not configurable) returns <c>false</c>
         /// </returns>
         bool ToggleLaneChangingAllowedWhenGoingStraight(ushort segmentId, bool startNode);
 
@@ -366,7 +366,7 @@ namespace TrafficManager.API.Manager {
         /// <param name="startNode">at start node?</param>
         /// <returns> <c>true</c> on success.
         /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
-        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// On failure (including when traffic rule is not configurable) returns <c>false</c>
         /// </returns>
         bool ToggleEnteringBlockedJunctionAllowed(ushort segmentId, bool startNode);
 
@@ -377,7 +377,7 @@ namespace TrafficManager.API.Manager {
         /// <param name="startNode">at start node?</param>
         /// <returns> <c>true</c> on success.
         /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
-        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// On failure (including when traffic rule is not configurable) returns <c>false</c>
         /// </returns>
         bool TogglePedestrianCrossingAllowed(ushort segmentId, bool startNode);
         #endregion
@@ -391,7 +391,7 @@ namespace TrafficManager.API.Manager {
         /// <param name="value">new value</param>
         /// <returns> <c>true</c> on success.
         /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
-        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// On failure (including when traffic rule is not configurable) returns <c>false</c>
         /// </returns>
         bool SetUturnAllowed(ushort segmentId, bool startNode, bool value);
 
@@ -403,7 +403,7 @@ namespace TrafficManager.API.Manager {
         /// <param name="value">new value</param>
         /// <returns> <c>true</c> on success.
         /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
-        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// On failure (including when traffic rule is not configurable) returns <c>false</c>
         /// </returns>
         bool SetNearTurnOnRedAllowed(ushort segmentId, bool startNode, bool value);
 
@@ -415,7 +415,7 @@ namespace TrafficManager.API.Manager {
         /// <param name="value">new value</param>
         /// <returns> <c>true</c> on success.
         /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
-        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// On failure (including when traffic rule is not configurable) returns <c>false</c>
         /// </returns>
         bool SetFarTurnOnRedAllowed(ushort segmentId, bool startNode, bool value);
 
@@ -428,7 +428,7 @@ namespace TrafficManager.API.Manager {
         /// <param name="value">new value</param>
         /// <returns> <c>true</c> on success.
         /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
-        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// On failure (including when traffic rule is not configurable) returns <c>false</c>
         /// </returns>
         bool SetTurnOnRedAllowed(bool near, ushort segmentId, bool startNode, bool value);
 
@@ -440,7 +440,7 @@ namespace TrafficManager.API.Manager {
         /// <param name="value">new value</param>
         /// <returns> <c>true</c> on success.
         /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
-        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// On failure (including when traffic rule is not configurable) returns <c>false</c>
         /// </returns>
         bool SetLaneChangingAllowedWhenGoingStraight(ushort segmentId, bool startNode, bool value);
 
@@ -452,7 +452,7 @@ namespace TrafficManager.API.Manager {
         /// <param name="value">new value</param>
         /// <returns> <c>true</c> on success.
         /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
-        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// On failure (including when traffic rule is not configurable) returns <c>false</c>
         /// </returns>
         bool SetEnteringBlockedJunctionAllowed(ushort segmentId, bool startNode, bool value);
 
@@ -464,7 +464,7 @@ namespace TrafficManager.API.Manager {
         /// <param name="value">new value</param>
         /// <returns> <c>true</c> on success.
         /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
-        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// On failure (including when traffic rule is not configurable) returns <c>false</c>
         /// </returns>
         bool SetPedestrianCrossingAllowed(ushort segmentId, bool startNode, bool value);
         #endregion
@@ -480,7 +480,7 @@ namespace TrafficManager.API.Manager {
         /// <param name="value">new value. Passing in <c>TernaryBool.Undefined</c> removes the traffic bool.</param>
         /// <returns> <c>true</c> on success.
         /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
-        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// On failure (including when traffic rule is not configurable) returns <c>false</c>
         /// </returns>
         bool SetUturnAllowed(ushort segmentId, bool startNode, TernaryBool value);
 
@@ -492,7 +492,7 @@ namespace TrafficManager.API.Manager {
         /// <param name="value">new value. Passing in <c>TernaryBool.Undefined</c> removes the traffic bool.</param>
         /// <returns> <c>true</c> on success.
         /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
-        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// On failure (including when traffic rule is not configurable) returns <c>false</c>
         /// </returns>
         bool SetNearTurnOnRedAllowed(ushort segmentId, bool startNode, TernaryBool value);
 
@@ -504,7 +504,7 @@ namespace TrafficManager.API.Manager {
         /// <param name="value">new value. Passing in <code>TernaryBool.Undefined</code> removes the traffic bool.</param>
         /// <returns> <c>true</c> on success.
         /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
-        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// On failure (including when traffic rule is not configurable) returns <c>false</c>
         /// </returns>
         bool SetFarTurnOnRedAllowed(ushort segmentId, bool startNode, TernaryBool value);
 
@@ -517,7 +517,7 @@ namespace TrafficManager.API.Manager {
         /// <param name="value">new value. Passing in <code>TernaryBool.Undefined</code> removes the traffic bool.</param>
         /// <returns> <c>true</c> on success.
         /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
-        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// On failure (including when traffic rule is not configurable) returns <c>false</c>
         /// </returns>
         bool SetTurnOnRedAllowed(bool near, ushort segmentId, bool startNode, TernaryBool value);
 
@@ -529,7 +529,7 @@ namespace TrafficManager.API.Manager {
         /// <param name="value">new value. Passing in <code>TernaryBool.Undefined</code> removes the traffic bool.</param>
         /// <returns> <c>true</c> on success.
         /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
-        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// On failure (including when traffic rule is not configurable) returns <c>false</c>
         /// </returns>
         bool SetLaneChangingAllowedWhenGoingStraight(ushort segmentId, bool startNode, TernaryBool value);
 
@@ -541,7 +541,7 @@ namespace TrafficManager.API.Manager {
         /// <param name="value">new value. Passing in <code>TernaryBool.Undefined</code> removes the traffic bool.</param>
         /// <returns> <c>true</c> on success.
         /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
-        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// On failure (including when traffic rule is not configurable) returns <c>false</c>
         /// </returns>
         bool SetEnteringBlockedJunctionAllowed(ushort segmentId, bool startNode, TernaryBool value);
 
@@ -553,7 +553,7 @@ namespace TrafficManager.API.Manager {
         /// <param name="value">new value. Passing in <code>TernaryBool.Undefined</code> removes the traffic bool.</param>
         /// <returns> <c>true</c> on success.
         /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
-        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// On failure (including when traffic rule is not configurable) returns <c>false</c>
         /// </returns>
         bool SetPedestrianCrossingAllowed(ushort segmentId, bool startNode, TernaryBool value);
         #endregion

--- a/TLM/TMPE.API/Manager/IJunctionRestrictionsManager.cs
+++ b/TLM/TMPE.API/Manager/IJunctionRestrictionsManager.cs
@@ -2,6 +2,7 @@ namespace TrafficManager.API.Manager {
     using CSUtil.Commons;
 
     public interface IJunctionRestrictionsManager {
+        #region Is<Traffic Rule>Configurable
         /// <summary>
         /// Determines if u-turn behavior may be controlled at the given segment end.
         /// </summary>
@@ -82,7 +83,9 @@ namespace TrafficManager.API.Manager {
         bool IsPedestrianCrossingAllowedConfigurable(ushort segmentId,
                                                      bool startNode,
                                                      ref NetNode node);
+        #endregion
 
+        #region GetDefault<Traffic Rule> 
         /// <summary>
         /// Determines the default setting for u-turns at the given segment end.
         /// </summary>
@@ -159,17 +162,21 @@ namespace TrafficManager.API.Manager {
         /// <param name="startNode">at start node?</param>
         /// <param name="node">node data</param>
         /// <returns><code>true</code> if crossing the road is allowed by default,
-        ///     <code>false</code> otherwise</returns>
+        ///     <c>false</c> otherwise
+        /// returns the default value if flag is not set.</returns>
         bool GetDefaultPedestrianCrossingAllowed(ushort segmentId,
                                                  bool startNode,
                                                  ref NetNode node);
+        #endregion
 
+        #region Is<Traffic Rule>Allowed
         /// <summary>
         /// Determines whether u-turns are allowed at the given segment end.
         /// </summary>
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
-        /// <returns><code>true</code> if u-turns are allowed, <code>false</code> otherwise</returns>
+        /// <returns><code>true</code> if u-turns are allowed, <c>false</c> otherwise
+        /// returns the default value if flag is not set.</returns>
         bool IsUturnAllowed(ushort segmentId, bool startNode);
 
         /// <summary>
@@ -177,8 +184,8 @@ namespace TrafficManager.API.Manager {
         /// </summary>
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
-        /// <returns><code>true</code> if turn-on-red is allowed for near turns, <code>false</code>
-        ///     otherwise</returns>
+        /// <returns><code>true</code> if turn-on-red is allowed for near turns, <c>false</c> otherwise
+        /// returns the default value if flag is not set.</returns>
         bool IsNearTurnOnRedAllowed(ushort segmentId, bool startNode);
 
         /// <summary>
@@ -186,8 +193,8 @@ namespace TrafficManager.API.Manager {
         /// </summary>
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
-        /// <returns><code>true</code> if turn-on-red is allowed for far turns, <code>false</code>
-        ///     otherwise</returns>
+        /// <returns><code>true</code> if turn-on-red is allowed for far turns, <c>false</c> otherwise
+        /// returns the default behaviour if flag is not set.  </returns>
         bool IsFarTurnOnRedAllowed(ushort segmentId, bool startNode);
 
         /// <summary>
@@ -196,7 +203,8 @@ namespace TrafficManager.API.Manager {
         /// <param name="near">for near turns?</param>
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
-        /// <returns><code>true</code> if turn-on-red is allowed, <code>false</code> otherwise</returns>
+        /// <returns><code>true</code> if turn-on-red is allowed, <c>false</c> otherwise
+        /// returns the default behaviour if flag is not set.</returns>
         bool IsTurnOnRedAllowed(bool near, ushort segmentId, bool startNode);
 
         /// <summary>
@@ -204,8 +212,9 @@ namespace TrafficManager.API.Manager {
         /// </summary>
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
-        /// <returns><code>true</code> if lane changing when going straight is allowed,
-        ///     <code>false</code> otherwise</returns>
+        /// <returns><code>true</code> if lane changing when going straight is allowed, <c>false</c> otherwise
+        /// returns the default behaviour if flag is not set.</returns>
+
         bool IsLaneChangingAllowedWhenGoingStraight(ushort segmentId, bool startNode);
 
         /// <summary>
@@ -213,7 +222,8 @@ namespace TrafficManager.API.Manager {
         /// </summary>
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
-        /// <returns><code>true</code> if entering a blocked junction is allowed, <code>false</code> otherwise</returns>
+        /// <returns><code>true</code> if entering a blocked junction is allowed, <code>false</code> otherwise
+        /// returns the default behaviour if flag is not set.</returns>
         bool IsEnteringBlockedJunctionAllowed(ushort segmentId, bool startNode);
 
         /// <summary>
@@ -221,16 +231,19 @@ namespace TrafficManager.API.Manager {
         /// </summary>
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
-        /// <returns><code>true</code> if crossing the road is allowed, <code>false</code>
-        ///     otherwise</returns>
+        /// <returns><code>true</code> if crossing the road is allowed, <c>false</c> otherwise.
+        /// returns the default value if flag is not set.</returns>
         bool IsPedestrianCrossingAllowed(ushort segmentId, bool startNode);
+        #endregion
 
+        #region Get<Traffic Rule>
         /// <summary>
         /// Retrieves the u-turn setting for the given segment end.
         /// </summary>
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
-        /// <returns>ternary u-turn flag</returns>
+        /// <returns>ternary u-turn flag.
+        /// returns <c>TernaryBool.Undefined</c> if the flag is not set.</returns>
         TernaryBool GetUturnAllowed(ushort segmentId, bool startNode);
 
         /// <summary>
@@ -238,7 +251,8 @@ namespace TrafficManager.API.Manager {
         /// </summary>
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
-        /// <returns>ternary turn-on-red flag for near turns</returns>
+        /// <returns>ternary turn-on-red flag for near turns.
+        /// returns <c>TernaryBool.Undefined</c> if the flag is not set.</returns>
         TernaryBool GetNearTurnOnRedAllowed(ushort segmentId, bool startNode);
 
         /// <summary>
@@ -246,7 +260,8 @@ namespace TrafficManager.API.Manager {
         /// </summary>
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
-        /// <returns>ternary turn-on-red flag for far turns</returns>
+        /// <returns>ternary turn-on-red flag for far turns.
+        /// returns <c>TernaryBool.Undefined</c> if the flag is not set.</returns>
         TernaryBool GetFarTurnOnRedAllowed(ushort segmentId, bool startNode);
 
         /// <summary>
@@ -255,7 +270,8 @@ namespace TrafficManager.API.Manager {
         /// <param name="near">for near turns?</param>
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
-        /// <returns>ternary turn-on-red flag</returns>
+        /// <returns>ternary turn-on-red flag.
+        /// returns <c>TernaryBool.Undefined</c> if the flag is not set.</returns>
         TernaryBool GetTurnOnRedAllowed(bool near, ushort segmentId, bool startNode);
 
         /// <summary>
@@ -263,7 +279,8 @@ namespace TrafficManager.API.Manager {
         /// </summary>
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
-        /// <returns>ternary lane changing flag</returns>
+        /// <returns>ternary lane changing flag.
+        /// returns <c>TernaryBool.Undefined</c> if the flag is not set.</returns>
         TernaryBool GetLaneChangingAllowedWhenGoingStraight(ushort segmentId, bool startNode);
 
         /// <summary>
@@ -271,7 +288,8 @@ namespace TrafficManager.API.Manager {
         /// </summary>
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
-        /// <returns>ternary "enter blocked junction" flag</returns>
+        /// <returns>ternary "enter blocked junction" flag.
+        /// returns <c>TernaryBool.Undefined</c> if the flag is not set.</returns>
         TernaryBool GetEnteringBlockedJunctionAllowed(ushort segmentId, bool startNode);
 
         /// <summary>
@@ -279,15 +297,21 @@ namespace TrafficManager.API.Manager {
         /// </summary>
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
-        /// <returns>ternary pedestrian crossing flag</returns>
+        /// <returns>ternary pedestrian crossing flag.
+        /// returns <c>TernaryBool.Undefined</c> if the flag is not set.</returns>
         TernaryBool GetPedestrianCrossingAllowed(ushort segmentId, bool startNode);
-
+        #endregion
+        
+        #region Toggle<Traffic Rule>
         /// <summary>
         /// Switches the u-turn flag for the given segment end.
         /// </summary>
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
-        /// <returns><code>true</code> on success, <code>false</code> otherwise</returns>
+        /// <returns> <c>true</c> on success.
+        /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
+        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// </returns>
         bool ToggleUturnAllowed(ushort segmentId, bool startNode);
 
         /// <summary>
@@ -295,7 +319,10 @@ namespace TrafficManager.API.Manager {
         /// </summary>
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
-        /// <returns><code>true</code> on success, <code>false</code> otherwise</returns>
+        /// <returns> <c>true</c> on success.
+        /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
+        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// </returns>
         bool ToggleNearTurnOnRedAllowed(ushort segmentId, bool startNode);
 
         /// <summary>
@@ -303,7 +330,10 @@ namespace TrafficManager.API.Manager {
         /// </summary>
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
-        /// <returns><code>true</code> on success, <code>false</code> otherwise</returns>
+        /// <returns> <c>true</c> on success.
+        /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
+        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// </returns>
         bool ToggleFarTurnOnRedAllowed(ushort segmentId, bool startNode);
 
         /// <summary>
@@ -312,7 +342,10 @@ namespace TrafficManager.API.Manager {
         /// <param name="near">for near turns?</param>
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
-        /// <returns><code>true</code> on success, <code>false</code> otherwise</returns>
+        /// <returns> <c>true</c> on success.
+        /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
+        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// </returns>
         bool ToggleTurnOnRedAllowed(bool near, ushort segmentId, bool startNode);
 
         /// <summary>
@@ -320,7 +353,10 @@ namespace TrafficManager.API.Manager {
         /// </summary>
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
-        /// <returns><code>true</code> on success, <code>false</code> otherwise</returns>
+        /// <returns> <c>true</c> on success.
+        /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
+        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// </returns>
         bool ToggleLaneChangingAllowedWhenGoingStraight(ushort segmentId, bool startNode);
 
         /// <summary>
@@ -328,7 +364,10 @@ namespace TrafficManager.API.Manager {
         /// </summary>
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
-        /// <returns><code>true</code> on success, <code>false</code> otherwise</returns>
+        /// <returns> <c>true</c> on success.
+        /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
+        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// </returns>
         bool ToggleEnteringBlockedJunctionAllowed(ushort segmentId, bool startNode);
 
         /// <summary>
@@ -336,16 +375,24 @@ namespace TrafficManager.API.Manager {
         /// </summary>
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
-        /// <returns><code>true</code> on success, <code>false</code> otherwise</returns>
+        /// <returns> <c>true</c> on success.
+        /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
+        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// </returns>
         bool TogglePedestrianCrossingAllowed(ushort segmentId, bool startNode);
+        #endregion
 
+        #region Set<Traffic Rule> : bool
         /// <summary>
         /// Sets the u-turn flag for the given segment end to the given value.
         /// </summary>
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
         /// <param name="value">new value</param>
-        /// <returns><code>true</code> on success, <code>false</code> otherwise</returns>
+        /// <returns> <c>true</c> on success.
+        /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
+        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// </returns>
         bool SetUturnAllowed(ushort segmentId, bool startNode, bool value);
 
         /// <summary>
@@ -354,7 +401,10 @@ namespace TrafficManager.API.Manager {
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
         /// <param name="value">new value</param>
-        /// <returns><code>true</code> on success, <code>false</code> otherwise</returns>
+        /// <returns> <c>true</c> on success.
+        /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
+        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// </returns>
         bool SetNearTurnOnRedAllowed(ushort segmentId, bool startNode, bool value);
 
         /// <summary>
@@ -363,7 +413,10 @@ namespace TrafficManager.API.Manager {
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
         /// <param name="value">new value</param>
-        /// <returns><code>true</code> on success, <code>false</code> otherwise</returns>
+        /// <returns> <c>true</c> on success.
+        /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
+        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// </returns>
         bool SetFarTurnOnRedAllowed(ushort segmentId, bool startNode, bool value);
 
         /// <summary>
@@ -373,7 +426,10 @@ namespace TrafficManager.API.Manager {
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
         /// <param name="value">new value</param>
-        /// <returns><code>true</code> on success, <code>false</code> otherwise</returns>
+        /// <returns> <c>true</c> on success.
+        /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
+        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// </returns>
         bool SetTurnOnRedAllowed(bool near, ushort segmentId, bool startNode, bool value);
 
         /// <summary>
@@ -382,7 +438,10 @@ namespace TrafficManager.API.Manager {
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
         /// <param name="value">new value</param>
-        /// <returns><code>true</code> on success, <code>false</code> otherwise</returns>
+        /// <returns> <c>true</c> on success.
+        /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
+        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// </returns>
         bool SetLaneChangingAllowedWhenGoingStraight(ushort segmentId, bool startNode, bool value);
 
         /// <summary>
@@ -391,7 +450,10 @@ namespace TrafficManager.API.Manager {
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
         /// <param name="value">new value</param>
-        /// <returns><code>true</code> on success, <code>false</code> otherwise</returns>
+        /// <returns> <c>true</c> on success.
+        /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
+        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// </returns>
         bool SetEnteringBlockedJunctionAllowed(ushort segmentId, bool startNode, bool value);
 
         /// <summary>
@@ -400,8 +462,109 @@ namespace TrafficManager.API.Manager {
         /// <param name="segmentId">segment id</param>
         /// <param name="startNode">at start node?</param>
         /// <param name="value">new value</param>
-        /// <returns><code>true</code> on success, <code>false</code> otherwise</returns>
+        /// <returns> <c>true</c> on success.
+        /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
+        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// </returns>
         bool SetPedestrianCrossingAllowed(ushort segmentId, bool startNode, bool value);
+        #endregion
+
+        #region Set<Traffic Rule> : TernaryBool
+
+
+        /// <summary>
+        /// Sets the u-turn flag for the given segment end to the given value.
+        /// </summary>
+        /// <param name="segmentId">segment id</param>
+        /// <param name="startNode">at start node?</param>
+        /// <param name="value">new value. Passing in <c>TernaryBool.Undefined</c> removes the traffic bool.</param>
+        /// <returns> <c>true</c> on success.
+        /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
+        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// </returns>
+        bool SetUturnAllowed(ushort segmentId, bool startNode, TernaryBool value);
+
+        /// <summary>
+        /// Sets the turn-on-red flag for near turns at the given segment end to the given value.
+        /// </summary>
+        /// <param name="segmentId">segment id</param>
+        /// <param name="startNode">at start node?</param>
+        /// <param name="value">new value. Passing in <c>TernaryBool.Undefined</c> removes the traffic bool.</param>
+        /// <returns> <c>true</c> on success.
+        /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
+        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// </returns>
+        bool SetNearTurnOnRedAllowed(ushort segmentId, bool startNode, TernaryBool value);
+
+        /// <summary>
+        /// Sets the turn-on-red flag for far turns at the given segment end to the given value.
+        /// </summary>
+        /// <param name="segmentId">segment id</param>
+        /// <param name="startNode">at start node?</param>
+        /// <param name="value">new value. Passing in <code>TernaryBool.Undefined</code> removes the traffic bool.</param>
+        /// <returns> <c>true</c> on success.
+        /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
+        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// </returns>
+        bool SetFarTurnOnRedAllowed(ushort segmentId, bool startNode, TernaryBool value);
+
+        /// <summary>
+        /// Sets the turn-on-red flag for the given turn type and segment end to the given value.
+        /// </summary>
+        /// <param name="near">for near turns?</param>
+        /// <param name="segmentId">segment id</param>
+        /// <param name="startNode">at start node?</param>
+        /// <param name="value">new value. Passing in <code>TernaryBool.Undefined</code> removes the traffic bool.</param>
+        /// <returns> <c>true</c> on success.
+        /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
+        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// </returns>
+        bool SetTurnOnRedAllowed(bool near, ushort segmentId, bool startNode, TernaryBool value);
+
+        /// <summary>
+        /// Sets the lane changing flag for the given segment end to the given value.
+        /// </summary>
+        /// <param name="segmentId">segment id</param>
+        /// <param name="startNode">at start node?</param>
+        /// <param name="value">new value. Passing in <code>TernaryBool.Undefined</code> removes the traffic bool.</param>
+        /// <returns> <c>true</c> on success.
+        /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
+        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// </returns>
+        bool SetLaneChangingAllowedWhenGoingStraight(ushort segmentId, bool startNode, TernaryBool value);
+
+        /// <summary>
+        /// Sets the "enter blocked junction" flag for the given segment end to the given value.
+        /// </summary>
+        /// <param name="segmentId">segment id</param>
+        /// <param name="startNode">at start node?</param>
+        /// <param name="value">new value. Passing in <code>TernaryBool.Undefined</code> removes the traffic bool.</param>
+        /// <returns> <c>true</c> on success.
+        /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
+        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// </returns>
+        bool SetEnteringBlockedJunctionAllowed(ushort segmentId, bool startNode, TernaryBool value);
+
+        /// <summary>
+        /// Sets the pedestrian crossing flag for the given segment end to the given value.
+        /// </summary>
+        /// <param name="segmentId">segment id</param>
+        /// <param name="startNode">at start node?</param>
+        /// <param name="value">new value. Passing in <code>TernaryBool.Undefined</code> removes the traffic bool.</param>
+        /// <returns> <c>true</c> on success.
+        /// Silently returns <c>true</c> if the given <paramref name="value"/> equals to the flag.
+        /// On failure (including when traffic rule is not configurable) returns false<c>false</c>
+        /// </returns>
+        bool SetPedestrianCrossingAllowed(ushort segmentId, bool startNode, TernaryBool value);
+        #endregion
+
+        /// <summary>
+        /// Removes all traffic rules for the input segment end.
+        /// </summary>
+        /// <param name="segmentId"></param>
+        /// <param name="startNode"></param>
+        /// <returns><c>true</c> on success, <c>false</c> otherwise</returns>
+        bool ClearSegmentEnd(ushort segmentId, bool startNode);
 
         /// <summary>
         /// Updates the default values for all junction restrictions and segments.

--- a/TLM/TMPE.API/Traffic/Data/SegmentEndFlags.cs
+++ b/TLM/TMPE.API/Traffic/Data/SegmentEndFlags.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.API.Traffic.Data {
+namespace TrafficManager.API.Traffic.Data {
     using System;
     using CSUtil.Commons;
 
@@ -56,28 +56,28 @@
                        : TernaryBoolUtil.ToBool(pedestrianCrossingAllowed);
         }
 
-        public void SetUturnAllowed(bool value) {
-            uturnAllowed = TernaryBoolUtil.ToTernaryBool(value);
+        public void SetUturnAllowed(TernaryBool value) {
+            uturnAllowed = value;
         }
 
-        public void SetNearTurnOnRedAllowed(bool value) {
-            nearTurnOnRedAllowed = TernaryBoolUtil.ToTernaryBool(value);
+        public void SetNearTurnOnRedAllowed(TernaryBool value) {
+            nearTurnOnRedAllowed = value;
         }
 
-        public void SetFarTurnOnRedAllowed(bool value) {
-            farTurnOnRedAllowed = TernaryBoolUtil.ToTernaryBool(value);
+        public void SetFarTurnOnRedAllowed(TernaryBool value) {
+            farTurnOnRedAllowed = value;
         }
 
-        public void SetLaneChangingAllowedWhenGoingStraight(bool value) {
-            straightLaneChangingAllowed = TernaryBoolUtil.ToTernaryBool(value);
+        public void SetLaneChangingAllowedWhenGoingStraight(TernaryBool value) {
+            straightLaneChangingAllowed = value;
         }
 
-        public void SetEnteringBlockedJunctionAllowed(bool value) {
-            enterWhenBlockedAllowed = TernaryBoolUtil.ToTernaryBool(value);
+        public void SetEnteringBlockedJunctionAllowed(TernaryBool value) {
+            enterWhenBlockedAllowed = value;
         }
 
-        public void SetPedestrianCrossingAllowed(bool value) {
-            pedestrianCrossingAllowed = TernaryBoolUtil.ToTernaryBool(value);
+        public void SetPedestrianCrossingAllowed(TernaryBool value) {
+            pedestrianCrossingAllowed = value;
         }
 
         public bool IsDefault() {

--- a/TLM/TMPE.API/Traffic/Data/SegmentFlags.cs
+++ b/TLM/TMPE.API/Traffic/Data/SegmentFlags.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.API.Traffic.Data {
+namespace TrafficManager.API.Traffic.Data {
     using System;
     using CSUtil.Commons;
 
@@ -79,7 +79,7 @@
                        : endNodeFlags.pedestrianCrossingAllowed;
         }
 
-        public void SetUturnAllowed(bool startNode, bool value) {
+        public void SetUturnAllowed(bool startNode, TernaryBool value) {
             if (startNode) {
                 startNodeFlags.SetUturnAllowed(value);
             } else {
@@ -87,7 +87,7 @@
             }
         }
 
-        public void SetNearTurnOnRedAllowed(bool startNode, bool value) {
+        public void SetNearTurnOnRedAllowed(bool startNode, TernaryBool value) {
             if (startNode) {
                 startNodeFlags.SetNearTurnOnRedAllowed(value);
             } else {
@@ -95,7 +95,7 @@
             }
         }
 
-        public void SetFarTurnOnRedAllowed(bool startNode, bool value) {
+        public void SetFarTurnOnRedAllowed(bool startNode, TernaryBool value) {
             if (startNode) {
                 startNodeFlags.SetFarTurnOnRedAllowed(value);
             } else {
@@ -103,7 +103,7 @@
             }
         }
 
-        public void SetLaneChangingAllowedWhenGoingStraight(bool startNode, bool value) {
+        public void SetLaneChangingAllowedWhenGoingStraight(bool startNode, TernaryBool value) {
             if (startNode) {
                 startNodeFlags.SetLaneChangingAllowedWhenGoingStraight(value);
             } else {
@@ -111,7 +111,7 @@
             }
         }
 
-        public void SetEnteringBlockedJunctionAllowed(bool startNode, bool value) {
+        public void SetEnteringBlockedJunctionAllowed(bool startNode, TernaryBool value) {
             if (startNode) {
                 startNodeFlags.SetEnteringBlockedJunctionAllowed(value);
             } else {
@@ -119,7 +119,7 @@
             }
         }
 
-        public void SetPedestrianCrossingAllowed(bool startNode, bool value) {
+        public void SetPedestrianCrossingAllowed(bool startNode, TernaryBool value) {
             if (startNode) {
                 startNodeFlags.SetPedestrianCrossingAllowed(value);
             } else {


### PR DESCRIPTION
Fixes #623 
I provided Interface for resting junction values. to do so provide `ternarybool.undefined` to a `set<traffic rule>()` function

provided documentation explaining what I explained in description of #623.

User Interface: choose Junction restriction tool -> select a junction -> press delete ~~or backspace~~

added KeyDown ~~and KeyUp~~ methods to keybind settings mimicking `Input.KeyDown()` ~~and `Input.KeyUp()`~~

modified the crowding key : https://crowdin.com/translate/tmpe/42/en-en#8844 to explain the addition of hotkey. can someone approve and merge it please?