### PR TITLE
Missed #563 being closed in 11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ This changelog includes all versions and major variants of the mod going all the
 - Fixed: Junction Manager not resetting on level unload (thanks kianzarrin!) (#637, #636)
 - Fixed: Stay in lane always assumed segment0 exists (thans kianzarrin!) (#619, #618)
 - Updated: Added 2 x Traffic Manager Plus and 1 x Traffic Manager as incompatible (#627)
-- Updated: Added 'Trees Respiration' mod as incompatible (depends on load order) (#614, #611)
+- Updated: Added 'Trees Respiration' mod as incompatible (depends on load order) (#614, #611, #563)
 - Updated: Replaced imports with fully qualified alphabetically sorted imports (#620)
 - Updated: Organised resource images in to folders (#641)
 - Meta: Old STABLE workshop page (LinuxFan - v10.20) is now obsolete and no longer maintained
@@ -60,7 +60,7 @@ This changelog includes all versions and major variants of the mod going all the
 - Fixed: Junction Manager not resetting on level unload (thanks kianzarrin!) (#637, #636)
 - Fixed: Stay in lane always assumed segment0 exists (thans kianzarrin!) (#619, #618)
 - Updated: Added 2 x Traffic Manager Plus and 1 x Traffic Manager as incompatible (#627)
-- Updated: Added 'Trees Respiration' mod as incompatible (depends on load order) (#614, #611)
+- Updated: Added 'Trees Respiration' mod as incompatible (depends on load order) (#614, #611, #563)
 - Updated: Replaced imports with fully qualified alphabetically sorted imports (#620)
 - Updated: Organised resource images in to folders (#641)
 - Meta: Old STABLE workshop page (LinuxFan - v10.20) is now obsolete and no longer maintained

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Official releases:
 - Fixed: Junction Manager not resetting on level unload (thanks kianzarrin!) (#637, #636)
 - Fixed: Stay in lane always assumed segment0 exists (thans kianzarrin!) (#619, #618)
 - Updated: Added 2 x Traffic Manager Plus and 1 x Traffic Manager as incompatible (#627)
-- Updated: Added 'Trees Respiration' mod as incompatible (depends on load order) (#614, #611)
+- Updated: Added 'Trees Respiration' mod as incompatible (depends on load order) (#614, #611, #563)
 - Updated: Replaced imports with fully qualified alphabetically sorted imports (#620)
 - Updated: Organised resource images in to folders (#641)
 - Meta: Old STABLE workshop page (LinuxFan - v10.20) is now obsolete and no longer maintained


### PR DESCRIPTION
Updated changelog and readme to reference it.

Also edited changelog on v11 LABS workshop page. Up to you if you want to update the v11 STABLE workshop page (main description and also change notes tab).