### PR TITLE
Centralise mod version

### DIFF
--- a/TLM/SharedAssemblyInfo.cs
+++ b/TLM/SharedAssemblyInfo.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyCopyright("Copyright © 2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+// [assembly: AssemblyVersion("1.0.0.0")]
+// [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("11.0.0.*")]

--- a/TLM/TLM/Properties/AssemblyInfo.cs
+++ b/TLM/TLM/Properties/AssemblyInfo.cs
@@ -1,36 +1,14 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using TrafficManager.Traffic;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("TLM")]
+[assembly: AssemblyProduct("TLM")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("TLM")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("70591292-D092-4DC5-AFB9-3AA950E240BE")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.*")]

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -108,6 +108,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="CodeProfiler.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="Custom\AI\CustomBuildingAI.cs" />

--- a/TLM/TLM/TrafficManagerMod.cs
+++ b/TLM/TLM/TrafficManagerMod.cs
@@ -28,8 +28,8 @@ namespace TrafficManager {
 
         public static string VersionString => ModVersion.ToString(2);
 
+        // Use SharedAssemblyInfo.cs to modify this version.
         public static Version ModVersion => typeof(TrafficManagerMod).Assembly.GetName().Version;
-
 
         public static readonly string ModName = "TM:PE " + VersionString + " " + BRANCH;
 

--- a/TLM/TLM/TrafficManagerMod.cs
+++ b/TLM/TLM/TrafficManagerMod.cs
@@ -26,9 +26,12 @@ namespace TrafficManager {
         public const uint GAME_VERSION_C = 3u;
         public const uint GAME_VERSION_BUILD = 2u;
 
-        public const string VERSION = "11.0";
+        public static string VersionString => ModVersion.ToString(2);
 
-        public static readonly string ModName = "TM:PE " + VERSION + " " + BRANCH;
+        public static Version ModVersion => typeof(TrafficManagerMod).Assembly.GetName().Version;
+
+
+        public static readonly string ModName = "TM:PE " + VersionString + " " + BRANCH;
 
         public string Name => ModName;
 
@@ -38,7 +41,7 @@ namespace TrafficManager {
         public void OnEnabled() {
             Log.InfoFormat(
                 "TM:PE enabled. Version {0}, Build {1} {2} for game version {3}.{4}.{5}-f{6}",
-                VERSION,
+                VersionString,
                 Assembly.GetExecutingAssembly().GetName().Version,
                 BRANCH,
                 GAME_VERSION_A,

--- a/TLM/TLM/UI/MainMenu/DebugMenu.cs
+++ b/TLM/TLM/UI/MainMenu/DebugMenu.cs
@@ -61,7 +61,7 @@ namespace TrafficManager.UI.MainMenu {
             relativePosition = new Vector3(resolution.x - Translation.GetMenuWidth() - 30f, 65f);
 
             _title = AddUIComponent<UILabel>();
-            _title.text = "Version " + TrafficManagerMod.VERSION;
+            _title.text = "Version " + TrafficManagerMod.VersionString;
             _title.relativePosition = new Vector3(50.0f, 5.0f);
 
             int y = 30;

--- a/TLM/TMPE.API/Properties/AssemblyInfo.cs
+++ b/TLM/TMPE.API/Properties/AssemblyInfo.cs
@@ -1,37 +1,14 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// Allgemeine Informationen über eine Assembly werden über die folgenden 
-// Attribute gesteuert. Ändern Sie diese Attributwerte, um die Informationen zu ändern,
-// die einer Assembly zugeordnet sind.
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
 [assembly: AssemblyTitle("TMPE.API")]
+[assembly: AssemblyProduct("TMPE.API")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("TMPE.API")]
-[assembly: AssemblyCopyright("Copyright ©  2018")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
-// Durch Festlegen von ComVisible auf "false" werden die Typen in dieser Assembly unsichtbar 
-// für COM-Komponenten.  Wenn Sie auf einen Typ in dieser Assembly von 
-// COM aus zugreifen müssen, sollten Sie das ComVisible-Attribut für diesen Typ auf "True" festlegen.
-[assembly: ComVisible(false)]
-
-// Die folgende GUID bestimmt die ID der Typbibliothek, wenn dieses Projekt für COM verfügbar gemacht wird
+// The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("c911d31c-c85d-42a8-a839-7b209a715495")]
-
-// Versionsinformationen für eine Assembly bestehen aus den folgenden vier Werten:
-//
-//      Hauptversion
-//      Nebenversion 
-//      Buildnummer
-//      Revision
-//
-// Sie können alle Werte angeben oder die standardmäßigen Build- und Revisionsnummern 
-// übernehmen, indem Sie "*" eingeben:
-// [assembly: AssemblyVersion("1.0.*")]
-//[assembly: AssemblyVersion("1.0.0.0")]
-//[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyVersion("1.0.*")]

--- a/TLM/TMPE.API/TMPE.API.csproj
+++ b/TLM/TMPE.API/TMPE.API.csproj
@@ -59,6 +59,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Geometry\ISegmentEndGeometry.cs" />
     <Compile Include="Geometry\INodeGeometry.cs" />
     <Compile Include="Geometry\ISegmentGeometry.cs" />

--- a/TLM/TMPE.CitiesGameBridge/Properties/AssemblyInfo.cs
+++ b/TLM/TMPE.CitiesGameBridge/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -6,30 +6,9 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("CitiesGameBridge")]
+[assembly: AssemblyProduct("CitiesGameBridge")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("CitiesGameBridge")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("3f2f7926-5d51-4880-a2b7-4594a10d7e54")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.*")]

--- a/TLM/TMPE.CitiesGameBridge/TMPE.CitiesGameBridge.csproj
+++ b/TLM/TMPE.CitiesGameBridge/TMPE.CitiesGameBridge.csproj
@@ -69,6 +69,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Factory\ServiceFactory.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Service\CitizenService.cs" />

--- a/TLM/TMPE.GenericGameBridge/Properties/AssemblyInfo.cs
+++ b/TLM/TMPE.GenericGameBridge/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -6,30 +6,9 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("GenericGameBridge")]
+[assembly: AssemblyProduct("GenericGameBridge")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("GenericGameBridge")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("663b991f-32a1-46e1-a4d3-540f8ea7f386")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.*")]

--- a/TLM/TMPE.GenericGameBridge/TMPE.GenericGameBridge.csproj
+++ b/TLM/TMPE.GenericGameBridge/TMPE.GenericGameBridge.csproj
@@ -71,6 +71,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Factory\IServiceFactory.cs" />
     <Compile Include="Service\ICitizenService.cs" />
     <Compile Include="Service\IBuildingService.cs" />

--- a/TLM/TMPE.sln
+++ b/TLM/TMPE.sln
@@ -1,7 +1,6 @@
-﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29503.13
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.539
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TLM", "TLM\TLM.csproj", "{7422AE58-8B0A-401C-9404-F4A438EFFE10}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -14,7 +13,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1D3D9CF0-947E-4A1A-BCFE-25F48E7908DF}"
 	ProjectSection(SolutionItems) = preProject
 		..\README.md = ..\README.md
-		SharedAssemblyInfo.cs = SharedAssemblyInfo.cs
+ 		SharedAssemblyInfo.cs = SharedAssemblyInfo.cs
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TMPE.UnitTest", "TMPE.UnitTest\TMPE.UnitTest.csproj", "{D0D1848A-9BAE-4121-89A0-66757D16BC73}"
@@ -130,8 +129,6 @@ Global
 		{F4BEABA8-E56B-4201-99C8-5E0115E87D1C}.Release LABS|Any CPU.Build.0 = Release|Any CPU
 		{F4BEABA8-E56B-4201-99C8-5E0115E87D1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F4BEABA8-E56B-4201-99C8-5E0115E87D1C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Benchmark|Any CPU.ActiveCfg = Debug|Any CPU
-		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Benchmark|Any CPU.Build.0 = Debug|Any CPU
 		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.FullDebug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -142,18 +139,20 @@ Global
 		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Release LABS|Any CPU.Build.0 = Release|Any CPU
 		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C911D31C-C85D-42A8-A839-7B209A715495}.Benchmark|Any CPU.ActiveCfg = Debug|Any CPU
-		{C911D31C-C85D-42A8-A839-7B209A715495}.Benchmark|Any CPU.Build.0 = Debug|Any CPU
+		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Benchmark|Any CPU.ActiveCfg = Debug|Any CPU
+		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Benchmark|Any CPU.Build.0 = Debug|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.FullDebug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.FullDebug|Any CPU.Build.0 = Debug|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.PF2_Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.PF2_Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C911D31C-C85D-42A8-A839-7B209A715495}.Release LABS|Any CPU.ActiveCfg = Release|Any CPU
-		{C911D31C-C85D-42A8-A839-7B209A715495}.Release LABS|Any CPU.Build.0 = Release|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C911D31C-C85D-42A8-A839-7B209A715495}.Release LABS|Any CPU.ActiveCfg = Release|Any CPU
+		{C911D31C-C85D-42A8-A839-7B209A715495}.Release LABS|Any CPU.Build.0 = Release|Any CPU
+		{C911D31C-C85D-42A8-A839-7B209A715495}.Benchmark|Any CPU.ActiveCfg = Debug|Any CPU
+		{C911D31C-C85D-42A8-A839-7B209A715495}.Benchmark|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TLM/TMPE.sln
+++ b/TLM/TMPE.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.539
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29503.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TLM", "TLM\TLM.csproj", "{7422AE58-8B0A-401C-9404-F4A438EFFE10}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -14,6 +14,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1D3D9CF0-947E-4A1A-BCFE-25F48E7908DF}"
 	ProjectSection(SolutionItems) = preProject
 		..\README.md = ..\README.md
+		SharedAssemblyInfo.cs = SharedAssemblyInfo.cs
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TMPE.UnitTest", "TMPE.UnitTest\TMPE.UnitTest.csproj", "{D0D1848A-9BAE-4121-89A0-66757D16BC73}"
@@ -129,6 +130,8 @@ Global
 		{F4BEABA8-E56B-4201-99C8-5E0115E87D1C}.Release LABS|Any CPU.Build.0 = Release|Any CPU
 		{F4BEABA8-E56B-4201-99C8-5E0115E87D1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F4BEABA8-E56B-4201-99C8-5E0115E87D1C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Benchmark|Any CPU.ActiveCfg = Debug|Any CPU
+		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Benchmark|Any CPU.Build.0 = Debug|Any CPU
 		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.FullDebug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -139,20 +142,18 @@ Global
 		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Release LABS|Any CPU.Build.0 = Release|Any CPU
 		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Benchmark|Any CPU.ActiveCfg = Debug|Any CPU
-		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Benchmark|Any CPU.Build.0 = Debug|Any CPU
+		{C911D31C-C85D-42A8-A839-7B209A715495}.Benchmark|Any CPU.ActiveCfg = Debug|Any CPU
+		{C911D31C-C85D-42A8-A839-7B209A715495}.Benchmark|Any CPU.Build.0 = Debug|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.FullDebug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.FullDebug|Any CPU.Build.0 = Debug|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.PF2_Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.PF2_Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C911D31C-C85D-42A8-A839-7B209A715495}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C911D31C-C85D-42A8-A839-7B209A715495}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.Release LABS|Any CPU.ActiveCfg = Release|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.Release LABS|Any CPU.Build.0 = Release|Any CPU
-		{C911D31C-C85D-42A8-A839-7B209A715495}.Benchmark|Any CPU.ActiveCfg = Debug|Any CPU
-		{C911D31C-C85D-42A8-A839-7B209A715495}.Benchmark|Any CPU.Build.0 = Debug|Any CPU
+		{C911D31C-C85D-42A8-A839-7B209A715495}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C911D31C-C85D-42A8-A839-7B209A715495}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TLM/TMPE.sln
+++ b/TLM/TMPE.sln
@@ -1,6 +1,7 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.539
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29503.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TLM", "TLM\TLM.csproj", "{7422AE58-8B0A-401C-9404-F4A438EFFE10}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -12,8 +13,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TLM", "TLM\TLM.csproj", "{7
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1D3D9CF0-947E-4A1A-BCFE-25F48E7908DF}"
 	ProjectSection(SolutionItems) = preProject
-		..\README.md = ..\README.md
- 		SharedAssemblyInfo.cs = SharedAssemblyInfo.cs
+		SharedAssemblyInfo.cs = SharedAssemblyInfo.cs
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TMPE.UnitTest", "TMPE.UnitTest\TMPE.UnitTest.csproj", "{D0D1848A-9BAE-4121-89A0-66757D16BC73}"
@@ -129,6 +129,8 @@ Global
 		{F4BEABA8-E56B-4201-99C8-5E0115E87D1C}.Release LABS|Any CPU.Build.0 = Release|Any CPU
 		{F4BEABA8-E56B-4201-99C8-5E0115E87D1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F4BEABA8-E56B-4201-99C8-5E0115E87D1C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Benchmark|Any CPU.ActiveCfg = Debug|Any CPU
+		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Benchmark|Any CPU.Build.0 = Debug|Any CPU
 		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.FullDebug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -139,20 +141,18 @@ Global
 		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Release LABS|Any CPU.Build.0 = Release|Any CPU
 		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Benchmark|Any CPU.ActiveCfg = Debug|Any CPU
-		{F8759084-DF5B-4A54-B73C-824640A8FA3F}.Benchmark|Any CPU.Build.0 = Debug|Any CPU
+		{C911D31C-C85D-42A8-A839-7B209A715495}.Benchmark|Any CPU.ActiveCfg = Debug|Any CPU
+		{C911D31C-C85D-42A8-A839-7B209A715495}.Benchmark|Any CPU.Build.0 = Debug|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.FullDebug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.FullDebug|Any CPU.Build.0 = Debug|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.PF2_Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.PF2_Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C911D31C-C85D-42A8-A839-7B209A715495}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C911D31C-C85D-42A8-A839-7B209A715495}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.Release LABS|Any CPU.ActiveCfg = Release|Any CPU
 		{C911D31C-C85D-42A8-A839-7B209A715495}.Release LABS|Any CPU.Build.0 = Release|Any CPU
-		{C911D31C-C85D-42A8-A839-7B209A715495}.Benchmark|Any CPU.ActiveCfg = Debug|Any CPU
-		{C911D31C-C85D-42A8-A839-7B209A715495}.Benchmark|Any CPU.Build.0 = Debug|Any CPU
+		{C911D31C-C85D-42A8-A839-7B209A715495}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C911D31C-C85D-42A8-A839-7B209A715495}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
fixed #678 
Added SharedAssemblyInfo.cs to the solution. this file is added as "LINKED FILE" to every TMPE project:
including these projects: TLM TMPE.* 
excluding these projects: CSUtil.Commons CSUtil.CameraInfo OptionsFramework

changed the `const` version string to a property whose value is same as the Version in `SharedAssemblyInfo.cs` according to  https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.getexecutingassembly?view=netframework-4.8

Now there is only one place to change assembly version: `SharedAssemblyInfo.cs`

Also updated the copy rights also inside `SharedAssemblyInfo.cs`

EDIT: I decided to do this because of https://github.com/krzychu124/Cities-Skylines-Traffic-Manager-President-Edition/issues/649#issuecomment-583849196

EDIT: 
you might notice some changes to TMPE.sln these changes are harmless and is mostly re-shufling lines. This is because when I added `SharedAssemblyInfo.cs`  to solution VS decided to do some tidying up as well!
 VS does not let me revert TMPE.sln I tried to do it with a external editor but then I started to get errors. I'd say let TMPE.sln to be as it is.
