### PR TITLE
Version 11.1.0

### DIFF
--- a/TLM/SharedAssemblyInfo.cs
+++ b/TLM/SharedAssemblyInfo.cs
@@ -16,16 +16,8 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // Version information for an assembly consists of the following four values:
-//
 //      Major Version
 //      Minor Version
 //      Build Number
 //      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-// [assembly: AssemblyVersion("1.0.0.0")]
-// [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyVersion("11.0.0.*")]
+[assembly: AssemblyVersion("11.1.0.*")]

--- a/TLM/TLM/TrafficManagerMod.cs
+++ b/TLM/TLM/TrafficManagerMod.cs
@@ -28,10 +28,12 @@ namespace TrafficManager {
         public const uint GAME_VERSION_C = 3u;
         public const uint GAME_VERSION_BUILD = 2u;
 
-        public static string VersionString => ModVersion.ToString(2);
-
-        // Use SharedAssemblyInfo.cs to modify this version.
+        // Use SharedAssemblyInfo.cs to modify TM:PE version
+        // External mods (eg. CSUR Toolbox) reference the versioning for compatibility purposes
         public static Version ModVersion => typeof(TrafficManagerMod).Assembly.GetName().Version;
+
+        // used for in-game display
+        public static string VersionString => ModVersion.ToString(3);
 
         public static readonly string ModName = "TM:PE " + VersionString + " " + BRANCH;
 


### PR DESCRIPTION
Bump version number to 11.1.0, ensure build is displayed in `VersionString`.

Fixes: #687
Note; CSUR team will need to update their "Don't patch TM:PE" to look for verison >= 11.1.1
https://github.com/citiesskylines-csur/CSURToolBox/pull/2